### PR TITLE
Knowledge Digest (Phase C) + security/review hardening

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,5 @@ htmlcov/
 
 # Mac-specific
 *.DS_Store
+
+.playwright-mcp/

--- a/analyze_activity.py
+++ b/analyze_activity.py
@@ -1,0 +1,295 @@
+"""
+analyze_activity.py — the Knowledge Digest chain's diff analyzer (node 3).
+
+Adapted from GitDigest's analyze_repository_activity. The three-tier token-splitting strategy is
+preserved exactly (it is the hard-won part): for each repo it fetches the real file diffs per commit
+(zero-trust: it reads code, not commit messages), then
+
+  Tier 1 (< 100K tokens): one LLM call for the whole week (max dot-connecting)
+  Tier 2 (100K–700K):     split by day, batching adjacent small days up to ~90K
+  Tier 3 (> 700K):        hybrid — compress oversized days to a per-commit budget, batch the rest
+
+The one substantive change: GitDigest's per-repo `repository_contexts` summary is replaced by the
+BRAIN (`profile:{repo}`), read ONLY if present. The brain is richer (architecture + conventions) and
+optional, so a first-run digest that races the brain build still analyzes fine, just with less context.
+
+Output (additive): `repository_analyses` = [{repository, changes:[{summary, category,
+contributing_commits}]}], one entry per repo. Grouping into per-group reports happens downstream.
+
+Testability: batch PLANNING (plan_batches / batch_small_days) is separated from LLM EXECUTION so the
+tiering is unit-tested without mocking the model. Flat script, no __main__ guard, init() first.
+"""
+import time
+from collections import defaultdict
+from datetime import datetime
+from typing import List, Dict, Any, Optional
+import requests
+from pydantic import BaseModel, Field
+import waveassist
+
+waveassist.init()   # credits gated once upstream in digest_check_and_init
+
+print("GitZoid Digest: starting repository activity analysis (analyze_activity) node")
+
+DEFAULT_MODEL = "anthropic/claude-sonnet-4.6"
+MAX_TOKENS = 2500
+TEMPERATURE = 0.4
+RATE_SLEEP = 0.5
+HTTP_TIMEOUT = 20
+GITHUB_API = "https://api.github.com"
+
+# Token thresholds for the splitting strategy (chars→tokens at ~3 chars/token).
+TIER_1_THRESHOLD = 100_000   # < 100K: single call
+TIER_2_THRESHOLD = 700_000   # 100K–700K: split by day; above → Tier 3 hybrid
+BATCH_THRESHOLD = 90_000     # combine adjacent small days up to this many tokens
+CHARS_PER_TOKEN = 3
+MAX_FILE_DIFF_SIZE = 90_000  # ~30K tokens; cap one file's diff
+
+NON_CODE_EXTENSIONS = {
+    ".jpg", ".jpeg", ".png", ".gif", ".svg", ".webp", ".ico", ".bmp", ".tiff",
+    ".mp4", ".avi", ".mov", ".wmv", ".flv", ".webm", ".mp3", ".wav", ".ogg", ".flac",
+    ".zip", ".tar", ".gz", ".rar", ".7z", ".exe", ".dll", ".so", ".dylib",
+    ".pdf", ".doc", ".docx", ".xls", ".xlsx", ".ppt", ".pptx",
+    ".woff", ".woff2", ".ttf", ".eot", ".otf", ".lock",
+}
+
+
+class Change(BaseModel):
+    summary: str = Field(description="Brief summary of what changed")
+    category: str = Field(description="Category: feature, improvement, fix, refactor, docs, test, chore")
+    contributing_commits: List[str] = Field(description="Commit SHAs that contributed to this change")
+
+
+class RepositoryAnalysis(BaseModel):
+    changes: List[Change] = Field(description="Distinct changes identified in this batch")
+
+
+# ---------------------------------------------------------------- pure helpers (tested)
+
+def is_non_code_file(filename: str) -> bool:
+    ext = "." + filename.split(".")[-1].lower() if "." in filename else ""
+    return ext in NON_CODE_EXTENSIONS
+
+
+def estimate_tokens(text: str) -> int:
+    return len(text) // CHARS_PER_TOKEN
+
+
+def choose_tier(total_tokens: int) -> int:
+    if total_tokens < TIER_1_THRESHOLD:
+        return 1
+    if total_tokens < TIER_2_THRESHOLD:
+        return 2
+    return 3
+
+
+def group_commits_by_day(commits) -> Dict[str, List[Dict[str, Any]]]:
+    by_day = defaultdict(list)
+    for c in commits:
+        ts = c.get("timestamp", "")
+        try:
+            day = datetime.fromisoformat(ts.replace("Z", "+00:00")).strftime("%Y-%m-%d") if ts else "unknown"
+        except Exception:
+            day = "unknown"
+        by_day[day].append(c)
+    return dict(by_day)
+
+
+def build_commit_context(commits, commit_diffs, token_budget: Optional[int] = None) -> str:
+    """Render commits + their diffs into one LLM context string. When token_budget is set, files are
+    packed smallest-first and a file (or the whole commit) is truncated/dropped once the budget is hit."""
+    parts, total_tokens = [], 0
+    for commit in commits:
+        sha = commit.get("sha", "")
+        text = (f"Commit: {sha[:7]}\nAuthor: {commit.get('author', 'Unknown')}\n"
+                f"Date: {commit.get('timestamp', '')}\nMessage: {commit.get('message', '')}\n")
+        files = commit_diffs.get(sha, [])
+        if token_budget:
+            files = sorted(files, key=lambda f: len(f.get("patch", "") or ""))
+        for f in files:
+            file_text = f"File: {f['filename']} ({f.get('status', 'modified')})\n"
+            if f.get("patch"):
+                file_text += f"```\n{f['patch']}\n```\n"
+            if token_budget and (total_tokens + estimate_tokens(file_text) > token_budget):
+                file_text = (f"File: {f['filename']} ({f.get('status', 'modified')})\n"
+                             f"[TRUNCATED: diff omitted due to token budget.]\n")
+            text += file_text
+        commit_tokens = estimate_tokens(text)
+        if token_budget and (total_tokens + commit_tokens > token_budget):
+            break
+        parts.append(text)
+        total_tokens += commit_tokens
+    return "\n---\n".join(parts)
+
+
+def batch_small_days(day_data, batch_threshold: int = BATCH_THRESHOLD):
+    """Combine adjacent small days into batches up to batch_threshold tokens. day_data is a list of
+    (day, day_commits, day_tokens). Returns [{commits, token_budget=None}]."""
+    batches, cur, cur_tokens = [], [], 0
+    for _day, day_commits, day_tokens in day_data:
+        if cur and (cur_tokens + day_tokens > batch_threshold):
+            batches.append({"commits": cur, "token_budget": None})
+            cur, cur_tokens = [], 0
+        cur = cur + list(day_commits)
+        cur_tokens += day_tokens
+    if cur:
+        batches.append({"commits": cur, "token_budget": None})
+    return batches
+
+
+def plan_batches(commits, commit_diffs):
+    """Decide the LLM calls for one repo's week using the three-tier strategy. Returns a list of
+    {commits, token_budget}; each entry is one LLM call. No model is invoked here."""
+    total = estimate_tokens(build_commit_context(commits, commit_diffs))
+    tier = choose_tier(total)
+    if tier == 1:
+        return [{"commits": commits, "token_budget": None}]
+
+    by_day = group_commits_by_day(commits)
+    days = sorted(by_day)
+
+    if tier == 2:
+        day_data = [(d, by_day[d], estimate_tokens(build_commit_context(by_day[d], commit_diffs))) for d in days]
+        return batch_small_days(day_data)
+
+    # Tier 3: compress oversized days, batch the rest like Tier 2.
+    large, small = [], []
+    for d in days:
+        dc = by_day[d]
+        dt = estimate_tokens(build_commit_context(dc, commit_diffs))
+        (large if dt > TIER_1_THRESHOLD else small).append((d, dc, dt))
+    batches = []
+    for _d, dc, _dt in large:
+        budget = TIER_1_THRESHOLD // max(1, len(dc))
+        batches.append({"commits": dc, "token_budget": budget})
+    batches.extend(batch_small_days(small))
+    return batches
+
+
+def brain_context_section(profile) -> str:
+    """A short context block from the brain (architecture + conventions), or "" if no brain yet.
+    Optional by design — the digest never hard-depends on study_repos."""
+    if not profile:
+        return ""
+    arch = (profile.get("architecture_summary") or "").strip()
+    convs = [str(c) for c in (profile.get("conventions") or []) if c][:5]
+    if not arch and not convs:
+        return ""
+    lines = ["Repository context (from GitZoid's profile):"]
+    if arch:
+        lines.append(f"- Architecture: {arch}")
+    if convs:
+        lines.append("- Conventions: " + "; ".join(convs))
+    return "\n".join(lines) + "\n---\n"
+
+
+# ---------------------------------------------------------------- github + llm (glue)
+
+def _headers(token):
+    return {"Authorization": f"token {token}", "Accept": "application/vnd.github+json"}
+
+
+def fetch_commit_diff(repo_path, sha, headers) -> List[Dict[str, Any]]:
+    """Real file diffs for one commit, non-code files dropped and oversized patches truncated."""
+    try:
+        r = requests.get(f"{GITHUB_API}/repos/{repo_path}/commits/{sha}", headers=headers, timeout=HTTP_TIMEOUT)
+        time.sleep(RATE_SLEEP)
+        if r.status_code != 200:
+            return []
+        files = []
+        for f in (r.json().get("files", []) or []):
+            filename = f.get("filename", "")
+            if is_non_code_file(filename):
+                continue
+            patch = f.get("patch", "") or ""
+            if len(patch) > MAX_FILE_DIFF_SIZE:
+                patch = patch[:MAX_FILE_DIFF_SIZE] + "\n\n[TRUNCATED: file diff exceeds size limit.]"
+            files.append({"filename": filename, "patch": patch, "status": f.get("status", "modified"),
+                          "additions": f.get("additions", 0), "deletions": f.get("deletions", 0)})
+        return files
+    except Exception as e:
+        print(f"⚠️ diff fetch failed for {repo_path}@{sha[:7]}: {e}")
+        return []
+
+
+def analyze_batch(repo_path, context, brain_section, model_name) -> Optional[RepositoryAnalysis]:
+    prompt = f"""Analyze the following Git commits and code changes from repository {repo_path}.
+
+{brain_section}
+Commits and Changes:
+{context}
+
+---
+
+Your task:
+1. Identify distinct changes/updates from these commits.
+2. Group related commits that contribute to the same logical change.
+3. Categorize each change as: feature, improvement, fix, refactor, docs, test, or chore.
+4. Write a clear, concise summary for each change (1-2 sentences).
+
+Guidelines:
+- Focus on WHAT changed.
+- Combine small related commits into single logical changes.
+- Skip trivial changes (typos, formatting) unless part of a larger change.
+- Include the commit SHAs that contributed to each change."""
+    try:
+        return waveassist.call_llm(model=model_name, prompt=prompt, response_model=RepositoryAnalysis,
+                                   max_tokens=MAX_TOKENS, temperature=TEMPERATURE)
+    except Exception as e:
+        print(f"⚠️ analysis LLM failed for {repo_path}: {e}")
+        return None
+
+
+def process_repository(repo_path, activity_data, profile, headers, model_name) -> Dict[str, Any]:
+    """One repo: fetch diffs, plan the tiered batches, run each, collect changes."""
+    commits = activity_data.get("commits", []) or []
+    if not commits:
+        return {"repository": repo_path, "changes": []}
+
+    commit_diffs = {}
+    for c in commits:
+        sha = c.get("sha", "")
+        if sha:
+            diffs = fetch_commit_diff(repo_path, sha, headers)
+            if diffs:
+                commit_diffs[sha] = diffs
+
+    brain_section = brain_context_section(profile)
+    all_changes = []
+    for batch in plan_batches(commits, commit_diffs):
+        context = build_commit_context(batch["commits"], commit_diffs, batch["token_budget"])
+        result = analyze_batch(repo_path, context, brain_section, model_name)
+        if result:
+            all_changes.extend([c.model_dump(by_alias=True) for c in result.changes])
+    return {"repository": repo_path, "changes": all_changes}
+
+
+# ---------------------------------------------------------------- driver (flat, fall-through)
+
+skip = waveassist.fetch_data("digest_skip_run", run_based=True, default="0") == "1"
+github_activity_data = {} if skip else (waveassist.fetch_data("github_activity_data", default={}) or {})
+
+if skip:
+    print("GitZoid Digest: digest_skip_run set; analyze_activity no-op.")
+
+if isinstance(github_activity_data, dict) and github_activity_data:
+    access_token = waveassist.fetch_data("github_access_token", default="") or ""
+    model_name = waveassist.fetch_data("model_name", default=DEFAULT_MODEL) or DEFAULT_MODEL
+    headers = _headers(access_token)
+
+    repository_analyses = []
+    for repo_path, activity_data in github_activity_data.items():
+        print(f"🔍 analyzing {repo_path}...")
+        try:
+            profile = waveassist.fetch_data(f"profile:{repo_path}", default={}) or {}   # brain, optional
+            analysis = process_repository(repo_path, activity_data or {}, profile, headers, model_name)
+            repository_analyses.append(analysis)
+            print(f"✓ {repo_path}: {len(analysis['changes'])} change(s)")
+        except Exception as e:
+            print(f"⚠️ analysis failed for {repo_path}: {e}; recording empty")
+            repository_analyses.append({"repository": repo_path, "changes": []})
+        waveassist.store_data("repository_analyses", repository_analyses, data_type="json")
+
+    total_changes = sum(len(a["changes"]) for a in repository_analyses)
+    print(f"GitZoid Digest: analysis complete — {total_changes} change(s) across "
+          f"{len(repository_analyses)} repo(s).")

--- a/config.yaml
+++ b/config.yaml
@@ -77,6 +77,52 @@ nodes:
     run_after:
       - deep_security_audit
 
+  # ---- Knowledge Digest chain (Phase C) ----
+  # A THIRD disconnected subgraph on its own WEEKLY clock (Mon 08:30 UTC, the GitDigest house default), so
+  # the multi-repo activity analysis never holds the 2-min review lock or the daily security lock. One
+  # starting node per connected subgraph — review, security, and digest are three independent chains, which
+  # the platform supports. digest_check_and_init gates (credits + enable_digest + lock) and resolves the
+  # per-group working set; send_digest releases digest_run_lock. The brain (profile:{repo}) is read ONLY if
+  # present — never a hard dependency: a run_after linking these nodes to study_repos would merge the digest
+  # and review subgraphs into one connected graph with two starting nodes and fail deploy validation.
+  - key: digest_check_and_init
+    name: DigestCheckAndInit
+    file_name: digest_check_and_init.py
+    starting_node: true
+    schedule:
+      cron: "30 8 * * 1"   # weekly, Monday 08:30 UTC
+      timezone: "UTC"
+
+  - key: fetch_activity
+    name: FetchActivity
+    file_name: fetch_activity.py
+    run_after:
+      - digest_check_and_init
+
+  - key: analyze_activity
+    name: AnalyzeActivity
+    file_name: analyze_activity.py
+    run_after:
+      - fetch_activity
+
+  - key: generate_business_report
+    name: GenerateBusinessReport
+    file_name: generate_business_report.py
+    run_after:
+      - analyze_activity
+
+  - key: generate_technical_report
+    name: GenerateTechnicalReport
+    file_name: generate_technical_report.py
+    run_after:
+      - generate_business_report
+
+  - key: send_digest
+    name: SendDigest
+    file_name: send_digest.py
+    run_after:
+      - generate_technical_report
+
 variables:
   - type: github
     name: github
@@ -165,6 +211,36 @@ variables:
     is_optional: true
     default_value: ""
     helper_message: "Additional emails to CC on security alerts, comma separated (e.g. security@acme.com, lead@acme.com). The account owner always receives them."
+
+  # Knowledge Digest toggle. Config default is "true" so a NEW user's setup wizard stores "true" and the
+  # digest is ON for them. EXISTING users never stored this key, so the node treats unset as OFF (no surprise
+  # weekly emails) — the OPPOSITE of enable_security, because the digest is a recurring email, not a silent
+  # watch. Existing users turn it on in one click. See digest_check_and_init.digest_enabled().
+  - name: enable_digest
+    key: enable_digest
+    display_name: Knowledge Digest
+    type: select
+    is_optional: true
+    default_value: "true"
+    helper_message: "Weekly leadership-ready digest of what actually shipped, read from your code diffs and grouped by project, with a security roll-up. One email a week, even in a quiet week."
+    options:
+      - name: "On"
+        key: "true"
+      - name: "Off"
+        key: "false"
+
+  # Project groups for the digest. Each group is {name, repos[], recipients[]} and gets its own weekly email
+  # (owner always primary, recipients CC'd). Repos belong to at most one group (exclusive membership, enforced
+  # in the dashboard input). Empty/unset → the node falls back to ONE implicit group over all selected repos,
+  # so the digest ships with zero dashboard dependency. Stored as a JSON string (data_type "list").
+  - name: digest_groups
+    key: digest_groups
+    display_name: "Knowledge Digest"
+    type: repo_groups
+    is_optional: true
+    depends_on: github
+    default_value: "[]"
+    helper_message: "Group your selected repos by project; each group gets its own weekly digest with its own recipients. Leave empty for a single digest covering all selected repos."
 
   - name: schedule
     key: schedule

--- a/deep_security_audit.py
+++ b/deep_security_audit.py
@@ -423,6 +423,7 @@ if repositories:
     due.sort(key=lambda r: (audit_state.get(r) or {}).get("last_audit_at", ""))
 
     candidates = []
+    scanned_ok = set()
     started = time.monotonic()
     for repo_path in due:
         if time.monotonic() - started > RUN_TIME_BUDGET_SECONDS:
@@ -455,6 +456,7 @@ if repositories:
             candidates.extend(repo_findings)
             audit_state[repo_path] = {"last_audit_at": datetime.now(timezone.utc).isoformat(),
                                       "last_audit_branch": branch, "last_audit_sha": head_sha}
+            scanned_ok.add(repo_path)   # fully audited this run → triage may resolve its code findings
             print(f"✓ {repo_path}: deep audit done over {len(files)} file(s), {len(repo_findings)} finding(s)")
         except Exception as e:
             print(f"⚠️ deep audit failed for {repo_path}: {e}; skipping repo")
@@ -464,5 +466,11 @@ if repositories:
     waveassist.store_data("security_audit_queue", queue, data_type="json")   # consumed entries removed
     existing = waveassist.fetch_data("security_candidates", run_based=True, default=[]) or []
     waveassist.store_data("security_candidates", existing + candidates,
+                          run_based=True, data_type="json")
+    # Publish the repos whose CODE was deep-audited this run so triage can resolve fixed code findings
+    # (authz/secret/backdoor). Kept separate from the daily dependency scan's set so neither class
+    # resolves the other's findings without being re-examined. Merge in case of re-entry.
+    prior_ok = set(waveassist.fetch_data("security_scanned_ok_code", run_based=True, default=[]) or [])
+    waveassist.store_data("security_scanned_ok_code", sorted(prior_ok | scanned_ok),
                           run_based=True, data_type="json")
     print(f"GitZoid Security: deep_security_audit produced {len(candidates)} candidate(s).")

--- a/digest_check_and_init.py
+++ b/digest_check_and_init.py
@@ -1,0 +1,206 @@
+"""
+digest_check_and_init.py — the Knowledge Digest chain's weekly starting node.
+
+Mirrors security_check_and_init (the Security chain's gate) but on a weekly clock and its OWN overlap
+lock, so the multi-repo activity analysis never blocks PR reviews or the daily security scan. It:
+  1. waveassist.init()
+  2. skips the whole chain cleanly if Digest is toggled off (enable_digest) or no repos are connected
+  3. resolves the per-group working set (with an implicit single-group fallback) ONCE, up front, so
+     every downstream node fans out over the same `digest_resolved_groups`
+  4. check_credits_and_notify(...) — stop the run if the account is out of credits
+  5. acquires `digest_run_lock` so overlapping weekly ticks don't double-send
+  6. stores `tentative_time_to_process` UPFRONT so the dashboard progress bar shows from second 0,
+     through the (slow) per-repo diff analysis in analyze_activity
+
+Why `enable_digest` defaults to OFF when unset (the OPPOSITE of enable_security): the digest is a
+recurring weekly EMAIL, not a silent watch. The config default_value is "true", so a NEW user's setup
+wizard stores "true" and the digest is ON for them. EXISTING users never stored the key, so an unset
+value reads as OFF here and they get no surprise email until they turn it on in one click. No backfill
+needed — the unset-vs-stored distinction does the work.
+
+Why resolve groups here and not downstream: the implicit single-group fallback (no configured groups →
+one digest over all selected repos) is a single decision that the whole chain must agree on. Computing
+it once in the gate and publishing `digest_resolved_groups` (run-based) keeps fetch/analyze/report/send
+fanning out over an identical working set.
+
+Why the brain is never a dependency: the digest READS profile:{repo} if present (see analyze_activity)
+but cannot run_after study_repos — that would merge the digest and review subgraphs into one connected
+graph with two starting nodes and fail deploy validation.
+
+Flat script, no __main__ guard. On no-credits it stores a display_output and raises (the run is marked
+failed — the intended "skipped, buy credits" signal). It does NOT raise on digest-disabled, missing
+repos, or a lock-skip: those are clean weekly no-ops, not failed runs.
+"""
+import re
+import json
+import uuid
+from datetime import datetime, timezone
+import waveassist
+
+# A weekly digest run analyzes a week of diffs across several repos plus two report syntheses, so this
+# matches the Review / Security / GitDigest gate (0.3), not a tiny per-call figure.
+CREDITS_NEEDED_FOR_RUN = 0.3
+
+# Single-run lock for the digest chain. Held from here until send_digest releases it. The TTL is a crash
+# safety net generous enough for the slowest legit run (a full week of diffs across every repo + PDF).
+RUN_LOCK_KEY = "digest_run_lock"
+LOCK_TTL_SECONDS = 3600   # 60 min
+
+# Upfront progress-bar budget (seconds). The per-repo activity analysis (0-7+ LLM calls over a week of
+# diffs) dominates a digest run; the two report syntheses + email/PDF are a small fixed tail. Budget per
+# repo so the dashboard bar shows from second 0. Over-estimating is safe: the frontend caps the bar at 80%.
+DIGEST_SECONDS_PER_REPO = 150  # budget for a week of diff analysis per repo (fetch + tiered LLM);
+                               # measured ~130-220s/repo end-to-end, so a slight over-estimate is right
+DIGEST_BASE_SECONDS = 30       # business + technical report synthesis + render/send
+
+
+def lock_is_active(lock, now=None) -> bool:
+    """A digest run is in progress iff a lock exists, has a timestamp, and is younger than the TTL."""
+    if not isinstance(lock, dict) or not lock.get("at"):
+        return False
+    now = now or datetime.now(timezone.utc)
+    try:
+        age = (now - datetime.fromisoformat(lock["at"])).total_seconds()
+    except Exception:
+        return False
+    return age < LOCK_TTL_SECONDS
+
+
+def digest_enabled(value) -> bool:
+    """Parse the optional `enable_digest` toggle. Default OFF (unset/empty) — EXISTING users who never
+    stored it get no surprise weekly email. Only an explicit truthy value turns it on; a NEW user's setup
+    wizard stores the config default "true". This is the OPPOSITE of security_enabled by design."""
+    if value is None or value == "":
+        return False
+    if isinstance(value, bool):
+        return value
+    return str(value).strip().lower() in ("true", "yes", "on", "1")
+
+
+def estimate_time_to_process(num_repos: int) -> int:
+    """Upfront seconds estimate for the whole digest chain, dominated by per-repo diff analysis.
+    Over-estimating is safe: the frontend caps the bar at 80%."""
+    if not isinstance(num_repos, int) or num_repos < 0:
+        num_repos = 0
+    return num_repos * DIGEST_SECONDS_PER_REPO + DIGEST_BASE_SECONDS
+
+
+def parse_groups(raw):
+    """The digest_groups input is stored by the dashboard as a JSON string (data_type "list"); fetch may
+    return it already-parsed or as a string. Normalize to a list; anything malformed → []."""
+    if isinstance(raw, list):
+        return raw
+    if isinstance(raw, str) and raw.strip():
+        try:
+            v = json.loads(raw)
+            return v if isinstance(v, list) else []
+        except Exception:
+            return []
+    return []
+
+
+def slugify(name, index) -> str:
+    """Stable kebab-case identity for a group's per-group state. Empty name → group-{1-based index}."""
+    s = re.sub(r"[^a-z0-9]+", "-", (name or "").strip().lower()).strip("-")
+    return s or f"group-{index + 1}"
+
+
+def _selected_ids(repositories):
+    out = []
+    for r in (repositories or []):
+        rid = r.get("id") if isinstance(r, dict) else r
+        if rid:
+            out.append(rid)
+    return out
+
+
+def resolve_groups(digest_groups, repositories):
+    """Normalize the digest_groups input into this run's working set. Each configured group's repos are
+    intersected with the globally-selected set (a repo deselected globally drops out silently); groups
+    left with no selected repo are dropped. If no non-empty group survives, fall back to ONE implicit
+    group over ALL selected repos (recipients empty → owner only). Slugs are unique and stable.
+    Returns [{name, repos, recipients, slug}]."""
+    selected = _selected_ids(repositories)
+    selected_set = set(selected)
+
+    groups = []
+    for g in (digest_groups or []):
+        if not isinstance(g, dict):
+            continue
+        repos = [p for p in (g.get("repos") or []) if p in selected_set]
+        if not repos:
+            continue
+        groups.append({"name": (g.get("name") or "").strip(),
+                       "repos": repos,
+                       "recipients": [e for e in (g.get("recipients") or []) if e],
+                       "implicit": False})
+
+    if not groups and selected:
+        # Implicit single-group fallback: unnamed + flagged so render leads with the brand title, not a
+        # bare "All repositories" label. Empty name slugifies to a stable "group-1".
+        groups = [{"name": "", "repos": selected, "recipients": [], "implicit": True}]
+
+    seen, out = set(), []
+    for i, g in enumerate(groups):
+        base = slugify(g["name"], i)
+        slug, n = base, 2
+        while slug in seen:
+            slug = f"{base}-{n}"
+            n += 1
+        seen.add(slug)
+        g["slug"] = slug
+        out.append(g)
+    return out
+
+
+waveassist.init()
+
+print("GitZoid Digest: starting weekly credits check and initialization...")
+
+enabled = digest_enabled(waveassist.fetch_data("enable_digest", default=None))
+repositories = waveassist.fetch_data("github_selected_resources", default=[]) or []
+groups = resolve_groups(parse_groups(waveassist.fetch_data("digest_groups", default=[])), repositories)
+num_repos = sum(len(g["repos"]) for g in groups)
+
+if not enabled or not groups:
+    reason = "Knowledge Digest is turned off" if not enabled else "no repositories are connected"
+    print(f"GitZoid Digest: {reason}; skipping this cycle (clean no-op).")
+    # Run-based STRING "1"/"0" — NOT a json bool (the SDK wraps that as a truthy {"value":"False"} dict).
+    waveassist.store_data("digest_skip_run", "1", run_based=True, data_type="string")
+    waveassist.store_data("display_output", {
+        "html_content": f"<p>GitZoid Digest run skipped — {reason}.</p>",
+    }, run_based=True, data_type="json")
+else:
+    success = waveassist.check_credits_and_notify(
+        required_credits=CREDITS_NEEDED_FOR_RUN,
+        assistant_name="GitZoid Digest",
+    )
+    if not success:
+        waveassist.store_data("display_output", {
+            "html_content": "<p>Credits were not available, the GitZoid Digest run was skipped.</p>",
+        }, run_based=True, data_type="json")
+        raise Exception("Credits were not available, the GitZoid Digest run was skipped.")
+
+    existing_lock = waveassist.fetch_data(RUN_LOCK_KEY, default={}) or {}
+    if lock_is_active(existing_lock):
+        print("GitZoid Digest: previous digest run still in progress; skipping this cycle.")
+        waveassist.store_data("digest_skip_run", "1", run_based=True, data_type="string")
+        waveassist.store_data("display_output", {
+            "html_content": "<p>GitZoid is already preparing a digest. This cycle will be skipped.</p>",
+        }, run_based=True, data_type="json")
+    else:
+        token = str(uuid.uuid4())
+        waveassist.store_data(RUN_LOCK_KEY,
+                              {"at": datetime.now(timezone.utc).isoformat(), "token": token},
+                              data_type="json")
+        # run-based so downstream digest nodes in THIS run know they hold the lock (and may release it).
+        waveassist.store_data("digest_run_lock_token", token, run_based=True, data_type="string")
+        waveassist.store_data("digest_skip_run", "0", run_based=True, data_type="string")
+        # The resolved working set every downstream node fans out over (implicit fallback already applied).
+        waveassist.store_data("digest_resolved_groups", groups, run_based=True, data_type="json")
+        # Upfront so the dashboard progress bar shows from second 0, through the slow per-repo analysis.
+        waveassist.store_data("tentative_time_to_process",
+                              str(estimate_time_to_process(num_repos)),
+                              run_based=True, data_type="string")
+        print(f"GitZoid Digest: credits OK, lock acquired. {len(groups)} group(s), {num_repos} repo(s); "
+              f"est ~{estimate_time_to_process(num_repos)}s.")

--- a/fetch_activity.py
+++ b/fetch_activity.py
@@ -1,0 +1,291 @@
+"""
+fetch_activity.py — the Knowledge Digest chain's GitHub activity collector (node 2).
+
+Adapted from GitDigest's fetch_github_activity, kept faithful to the parts that work: a 7-day window,
+GraphQL active-branch detection (only branches with commits after `since`), REST commit fetch from
+those branches with SHA dedupe, open/recently-merged PRs, and a bot filter. It does NOT fetch diffs —
+analyze_activity reads the actual diffs per commit.
+
+Two GitZoid adaptations:
+  - it honours the chain's `digest_skip_run` no-op (an off/overlapping cycle does zero HTTP), and
+  - it scopes to the union of repos across `digest_resolved_groups` (the gate already applied the
+    implicit single-group fallback), not the raw selection — a globally-deselected repo never gets a
+    network round-trip.
+
+Output (additive keys): `github_activity_data` ({repo: {commits, pull_requests}}) and
+`report_date_range`. Flat script, no __main__ guard, init() first, fall-through on empty.
+"""
+import time
+from datetime import datetime, timezone, timedelta
+from typing import Dict, Any, List
+import requests
+import waveassist
+
+waveassist.init()   # credits gated once upstream in digest_check_and_init
+
+print("GitZoid Digest: starting GitHub activity fetch (fetch_activity) node")
+
+GITHUB_API = "https://api.github.com"
+GRAPHQL_URL = "https://api.github.com/graphql"
+DAYS_TO_FETCH = 7
+RATE_SLEEP = 0.5
+HTTP_TIMEOUT = 20
+MAX_BRANCH_PAGES = 50      # 50 * 100 = 5,000 branches
+MAX_COMMIT_PAGES = 10      # 10 * 100 = 1,000 commits per branch
+
+_COMMON_BOTS = {
+    "dependabot", "renovate", "github-actions", "codecov", "greenkeeper", "snyk-bot", "mergify",
+    "stale", "allcontributors", "imgbot", "semantic-release-bot", "renovate-bot", "dependabot-preview",
+}
+
+
+# ---------------------------------------------------------------- pure helpers (tested)
+
+def is_bot_user(user) -> bool:
+    """A commit/PR author is a bot if GitHub types it Bot, its login ends in [bot], or it is a
+    well-known automation account."""
+    if not user:
+        return False
+    if user.get("type") == "Bot":
+        return True
+    login = (user.get("login") or "").lower()
+    if login.endswith("[bot]"):
+        return True
+    return login in _COMMON_BOTS
+
+
+def parse_commit(commit) -> Dict[str, Any]:
+    """Shape one REST commit into our record, or None if it has no SHA or is bot-authored."""
+    sha = commit.get("sha", "")
+    if not sha:
+        return None
+    author = commit.get("author") or {}
+    committer = commit.get("committer") or {}
+    if is_bot_user(author) or is_bot_user(committer):
+        return None
+    cdata = commit.get("commit", {}) or {}
+    cauthor = cdata.get("author", {}) or {}
+    return {
+        "sha": sha,
+        "message": cdata.get("message", ""),
+        "author": author.get("login") if author else cauthor.get("name", "Unknown"),
+        "timestamp": cauthor.get("date", ""),
+        "url": commit.get("html_url", ""),
+    }
+
+
+def _to_dt(value):
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except Exception:
+        return None
+
+
+def pr_in_window(pr, since) -> bool:
+    """A PR counts for the week if it was created, merged, or updated at/after `since`."""
+    for field in ("created_at", "merged_at", "updated_at"):
+        dt = _to_dt(pr.get(field))
+        if dt and dt >= since:
+            return True
+    return False
+
+
+def parse_pr(pr, state) -> Dict[str, Any]:
+    """Shape one REST pull request into our record."""
+    user = pr.get("user") or {}
+    return {
+        "number": pr.get("number"),
+        "title": pr.get("title", ""),
+        "description": pr.get("body", "") or "",
+        "status": state,
+        "author": user.get("login", "Unknown"),
+        "timestamp": pr.get("created_at", ""),
+        "created_at": pr.get("created_at", ""),
+        "merged_at": pr.get("merged_at") or "",
+        "updated_at": pr.get("updated_at", ""),
+        "url": pr.get("html_url", ""),
+        "head_sha": (pr.get("head") or {}).get("sha", ""),
+        "base_branch": (pr.get("base") or {}).get("ref", ""),
+    }
+
+
+def filter_active_branches(branches, since) -> List[str]:
+    """Branch names whose latest commit is at/after `since`. Unparseable dates are excluded (safe)."""
+    out = []
+    for b in (branches or []):
+        dt = _to_dt(b.get("committedDate"))
+        if dt and dt >= since:
+            out.append(b.get("name"))
+    return [n for n in out if n]
+
+
+def dedupe_commits(commits) -> List[Dict[str, Any]]:
+    """Drop repeated SHAs (the same commit reachable from several active branches), preserving order."""
+    seen, out = set(), []
+    for c in (commits or []):
+        sha = c.get("sha", "")
+        if sha and sha not in seen:
+            seen.add(sha)
+            out.append(c)
+    return out
+
+
+def build_date_range(start, end) -> Dict[str, str]:
+    """The week window for the email header."""
+    return {
+        "start_date": start.isoformat(),
+        "end_date": end.isoformat(),
+        "start_date_formatted": start.strftime("%B %d, %Y"),
+        "end_date_formatted": end.strftime("%B %d, %Y"),
+    }
+
+
+def repos_to_scan(resolved_groups) -> List[str]:
+    """Union of repos across every resolved group (the gate already applied the implicit fallback)."""
+    repos = set()
+    for g in (resolved_groups or []):
+        for r in (g.get("repos") or []):
+            if r:
+                repos.add(r)
+    return sorted(repos)
+
+
+# ---------------------------------------------------------------- github fetch (HTTP glue)
+
+def _headers(token):
+    return {"Authorization": f"token {token}", "Accept": "application/vnd.github+json"}
+
+
+def fetch_branches_with_dates(repo_path, headers) -> List[Dict[str, str]]:
+    """All branches with their latest commit date via GraphQL (paginated)."""
+    parts = repo_path.split("/")
+    if len(parts) != 2:
+        print(f"⚠️ invalid repo path: {repo_path}")
+        return []
+    owner, name = parts
+    query = """
+    query($owner: String!, $name: String!, $cursor: String) {
+      repository(owner: $owner, name: $name) {
+        refs(refPrefix: "refs/heads/", first: 100, after: $cursor) {
+          pageInfo { hasNextPage endCursor }
+          nodes { name target { ... on Commit { committedDate } } }
+        }
+      }
+    }"""
+    branches, cursor, page = [], None, 1
+    try:
+        while True:
+            r = requests.post(GRAPHQL_URL, headers=headers,
+                              json={"query": query, "variables": {"owner": owner, "name": name, "cursor": cursor}},
+                              timeout=HTTP_TIMEOUT)
+            time.sleep(RATE_SLEEP)
+            if r.status_code != 200:
+                print(f"⚠️ branches GraphQL {repo_path}: HTTP {r.status_code}")
+                break
+            data = r.json()
+            if "errors" in data:
+                print(f"⚠️ branches GraphQL {repo_path}: {data['errors']}")
+                break
+            refs = (((data.get("data") or {}).get("repository") or {}).get("refs") or {})
+            for node in (refs.get("nodes") or []):
+                cdate = (node.get("target") or {}).get("committedDate", "")
+                if node.get("name") and cdate:
+                    branches.append({"name": node["name"], "committedDate": cdate})
+            info = refs.get("pageInfo") or {}
+            if not info.get("hasNextPage") or page >= MAX_BRANCH_PAGES:
+                break
+            cursor = info.get("endCursor")
+            page += 1
+    except Exception as e:
+        print(f"⚠️ branches fetch failed for {repo_path}: {e}")
+    return branches
+
+
+def fetch_commits(repo_path, headers, branch_name, since) -> List[Dict[str, Any]]:
+    """Commits on one branch since `since` (paginated), shaped + bot-filtered."""
+    out, page = [], 1
+    try:
+        while True:
+            r = requests.get(f"{GITHUB_API}/repos/{repo_path}/commits", headers=headers,
+                             params={"sha": branch_name, "since": since.isoformat(), "per_page": 100, "page": page},
+                             timeout=HTTP_TIMEOUT)
+            time.sleep(RATE_SLEEP)
+            if r.status_code != 200:
+                break
+            commits = r.json()
+            if not commits:
+                break
+            for c in commits:
+                rec = parse_commit(c)
+                if rec:
+                    out.append(rec)
+            if len(commits) < 100 or page >= MAX_COMMIT_PAGES:
+                break
+            page += 1
+    except Exception as e:
+        print(f"⚠️ commits fetch failed for {repo_path}@{branch_name}: {e}")
+    return out
+
+
+def fetch_pull_requests(repo_path, headers, since) -> List[Dict[str, Any]]:
+    """Open + recently-merged PRs touched within the window, shaped + bot-filtered."""
+    out = []
+    for state in ("open", "closed"):
+        try:
+            r = requests.get(f"{GITHUB_API}/repos/{repo_path}/pulls", headers=headers,
+                             params={"state": state, "sort": "updated", "direction": "desc", "per_page": 100},
+                             timeout=HTTP_TIMEOUT)
+            time.sleep(RATE_SLEEP)
+            if r.status_code != 200:
+                continue
+            for pr in r.json():
+                if is_bot_user(pr.get("user") or {}):
+                    continue
+                if not pr_in_window(pr, since):
+                    continue
+                out.append(parse_pr(pr, state))
+        except Exception as e:
+            print(f"⚠️ {state} PRs fetch failed for {repo_path}: {e}")
+    return out
+
+
+# ---------------------------------------------------------------- driver (flat, fall-through)
+
+skip = waveassist.fetch_data("digest_skip_run", run_based=True, default="0") == "1"
+resolved_groups = [] if skip else (waveassist.fetch_data("digest_resolved_groups", run_based=True, default=[]) or [])
+
+if skip:
+    print("GitZoid Digest: digest_skip_run set; fetch_activity no-op.")
+
+repos = repos_to_scan(resolved_groups)
+if repos:
+    access_token = waveassist.fetch_data("github_access_token", default="") or ""
+    headers = _headers(access_token)
+
+    end_date = datetime.now(timezone.utc)
+    since = end_date - timedelta(days=DAYS_TO_FETCH)
+
+    github_activity_data = {}
+    for repo_path in repos:
+        print(f"📊 {repo_path}: fetching activity...")
+        try:
+            branches = fetch_branches_with_dates(repo_path, headers)
+            active = filter_active_branches(branches, since)
+            commits = []
+            for branch_name in active:
+                commits.extend(fetch_commits(repo_path, headers, branch_name, since))
+            commits = dedupe_commits(commits)
+            prs = fetch_pull_requests(repo_path, headers, since)
+            github_activity_data[repo_path] = {"commits": commits, "pull_requests": prs}
+            print(f"✓ {repo_path}: {len(commits)} commit(s), {len(prs)} PR(s) over {len(active)} active branch(es)")
+        except Exception as e:
+            print(f"⚠️ activity fetch failed for {repo_path}: {e}; recording empty")
+            github_activity_data[repo_path] = {"commits": [], "pull_requests": []}
+        waveassist.store_data("github_activity_data", github_activity_data, data_type="json")
+
+    waveassist.store_data("report_date_range", build_date_range(since, end_date), data_type="json")
+    total_commits = sum(len(d["commits"]) for d in github_activity_data.values())
+    total_prs = sum(len(d["pull_requests"]) for d in github_activity_data.values())
+    print(f"GitZoid Digest: fetched {total_commits} commit(s), {total_prs} PR(s) across {len(repos)} repo(s).")

--- a/generate_business_report.py
+++ b/generate_business_report.py
@@ -1,0 +1,169 @@
+"""
+generate_business_report.py — the Knowledge Digest chain's business report (node 4, per group).
+
+Adapted from GitDigest: same BusinessReport shape (executive_summary + 1-3 shipped_features) and the
+rolling 1-week history for continuity, but fanned out PER resolved group — each group is its own
+"project" with its own report and its own history. Repository context comes from the brain
+(profile:{repo}, optional) instead of the dropped repository_contexts node.
+
+For each group it filters the per-repo analyses to that group's repos; an idle group (no changes)
+gets a deterministic empty report with no LLM call. Per-group reports are published run-based as
+`digest_business_reports = {slug: report}` for the technical node and send_digest; per-group history
+lives in the persistent `digest_state = {slug: {business_report_history, ...}}`.
+
+Flat script, no __main__ guard, init() first, no sibling imports (helpers duplicated by design).
+"""
+import json
+from datetime import datetime, timezone
+from typing import List, Dict, Any
+from pydantic import BaseModel, Field
+import waveassist
+
+waveassist.init()   # credits gated once upstream in digest_check_and_init
+
+print("GitZoid Digest: starting business report generation (generate_business_report) node")
+
+DEFAULT_MODEL = "anthropic/claude-sonnet-4.6"
+MAX_TOKENS = 2500
+TEMPERATURE = 0.4
+
+
+class BusinessReport(BaseModel):
+    executive_summary: str = Field(description="2 sentences on the week's biggest impact")
+    shipped_features: List[str] = Field(description="Top 1-3 user-facing capabilities completed")
+
+
+# ---------------------------------------------------------------- pure helpers (tested)
+
+def filter_analyses(repository_analyses, group_repos):
+    s = set(group_repos or [])
+    return [a for a in (repository_analyses or []) if a.get("repository") in s]
+
+
+def count_changes(analyses):
+    return sum(len(a.get("changes", []) or []) for a in (analyses or []))
+
+
+def build_changes_context(analyses) -> str:
+    """Compact JSON of {repo: changes} for repos that actually changed (the PRIMARY source)."""
+    result = {a.get("repository", "Unknown"): a.get("changes", [])
+              for a in (analyses or []) if a.get("changes")}
+    return json.dumps(result, default=str, ensure_ascii=False, separators=(",", ":")) if result else ""
+
+
+def build_history_context(history) -> str:
+    if not history:
+        return ""
+    parts = ["Previous week's business report, for context only:"]
+    for entry in history:
+        parts.append(f"Week of {entry.get('week', 'Unknown')}:\n"
+                     f"{json.dumps(entry.get('report', {}), default=str, ensure_ascii=False, separators=(',', ':'))}")
+    return "\n---\n".join(parts)
+
+
+def roll_history(history, week, report):
+    """Keep the most recent prior week, then append this week (max 2 entries)."""
+    hist = list(history) if isinstance(history, list) else []
+    hist = hist[-1:]
+    hist.append({"week": week, "report": report})
+    return hist
+
+
+def brain_block(profiles_by_repo) -> str:
+    """Concatenated brain context (architecture) for the group's active repos, or "" if no brain."""
+    parts = []
+    for repo, profile in (profiles_by_repo or {}).items():
+        arch = ((profile or {}).get("architecture_summary") or "").strip()
+        if arch:
+            parts.append(f"- {repo}: {arch}")
+    return ("Repository context (from GitZoid's profile):\n" + "\n".join(parts)) if parts else ""
+
+
+def build_prompt(project_name, changes_context, history_context, brain_context) -> str:
+    parts = [
+        ("You are a business-focused advisor reporting to a busy CEO. "
+         f"Review the development activity for {project_name}. "
+         "Extract the 2-3 biggest user-facing wins. Ignore the plumbing. "
+         "If a section has no significant updates, strictly return an empty list."),
+    ]
+    if brain_context:
+        parts.append("\n<Repo Context>\n" + brain_context)
+    if history_context:
+        parts.append("\n<Previous Report Context>\n" + history_context)
+    if changes_context:
+        parts.append("\n*** PRIMARY SOURCE: Code Changes Summarized ***\n" + changes_context)
+    parts.append("""
+Create a concise business report identifying the headline features (The Signal).
+
+CRITICAL INSTRUCTIONS:
+- Extract headlines only: the 2-3 biggest user-facing features. Ignore internal refactors and fixes
+  unless they directly enable a major new capability.
+- Translate technical changes into user-facing benefits and business outcomes.
+- Skip plumbing, maintenance, and minor improvements.
+
+1. executive_summary: exactly 2 sentences on the week's biggest impact, outcome-focused.
+2. shipped_features: MAXIMUM 3 (ideally 1-3) completed, user-facing capabilities in plain language.
+
+Write for a busy CEO. Avoid jargon. Be honest but positive. Plain prose in short sentences. Do NOT
+use em dashes, and do not use a hyphen as a connector between clauses. No emojis in the text.""")
+    return "".join(parts)
+
+
+def empty_report(project_name):
+    return {"executive_summary": f"No development activity was recorded for {project_name} this week.",
+            "shipped_features": []}
+
+
+# ---------------------------------------------------------------- driver (flat, fall-through)
+
+skip = waveassist.fetch_data("digest_skip_run", run_based=True, default="0") == "1"
+groups = [] if skip else (waveassist.fetch_data("digest_resolved_groups", run_based=True, default=[]) or [])
+
+if skip:
+    print("GitZoid Digest: digest_skip_run set; generate_business_report no-op.")
+
+if groups:
+    repository_analyses = waveassist.fetch_data("repository_analyses", default=[]) or []
+    model_name = waveassist.fetch_data("model_name", default=DEFAULT_MODEL) or DEFAULT_MODEL
+    digest_state = waveassist.fetch_data("digest_state", default={}) or {}
+    week = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+    business_reports = {}
+    for group in groups:
+        slug = group.get("slug")
+        name = group.get("name") or "your repositories"
+        analyses = filter_analyses(repository_analyses, group.get("repos") or [])
+        state = digest_state.get(slug) or {}
+
+        if count_changes(analyses) == 0:
+            business_reports[slug] = empty_report(name)
+            print(f"· {slug}: no activity; empty business report")
+            continue
+
+        profiles = {a["repository"]: (waveassist.fetch_data(f"profile:{a['repository']}", default={}) or {})
+                    for a in analyses if a.get("changes")}
+        prompt = build_prompt(name, build_changes_context(analyses),
+                              build_history_context(state.get("business_report_history") or []),
+                              brain_block(profiles))
+        try:
+            result = waveassist.call_llm(model=model_name, prompt=prompt, response_model=BusinessReport,
+                                         max_tokens=MAX_TOKENS, temperature=TEMPERATURE)
+        except Exception as e:
+            print(f"⚠️ business LLM failed for {slug}: {e}")
+            result = None
+
+        if result:
+            report = result.model_dump(by_alias=True)
+            business_reports[slug] = report
+            state["business_report_history"] = roll_history(state.get("business_report_history") or [], week, report)
+            digest_state[slug] = state
+            print(f"✓ {slug}: business report generated")
+        else:
+            report = empty_report(name)
+            report["generation_failed"] = True   # LLM raised — NOT a quiet week; send_digest must skip this group
+            business_reports[slug] = report
+            print(f"⚠️ {slug}: business report generation FAILED (LLM error); flagged")
+
+    waveassist.store_data("digest_business_reports", business_reports, run_based=True, data_type="json")
+    waveassist.store_data("digest_state", digest_state, data_type="json")
+    print(f"GitZoid Digest: business reports for {len(business_reports)} group(s).")

--- a/generate_review.py
+++ b/generate_review.py
@@ -616,8 +616,8 @@ def verify_posted_findings(findings, pr, token, model_name, diff_lines, severity
             v = None
         if not v:
             survivors.append(f); continue                       # unavailable/error → fail open
-        if not v.get("is_real"):
-            dropped.append({**f, "_drop_reason": v.get("reason", "")}); continue
+        if v.get("is_real") is False:                           # drop ONLY on explicit refutation;
+            dropped.append({**f, "_drop_reason": v.get("reason", "")}); continue  # None/missing → keep (fail open)
         # Verified real → trust the re-judged severity, and treat confidence as high.
         survivors.append({**f, "severity": v.get("true_severity") or f.get("severity"), "confidence": "high"})
     kept, verdict, _ = apply_gate(survivors, diff_lines, seen_sigs=set(), severity_threshold=severity_threshold)

--- a/generate_technical_report.py
+++ b/generate_technical_report.py
@@ -1,0 +1,244 @@
+"""
+generate_technical_report.py — the Knowledge Digest chain's technical report (node 5, per group).
+
+Adapted from GitDigest: same TechnicalReport shape (repository_deep_dive + poem), fanned out per
+resolved group, with the business report as context to avoid duplication. The substantive addition is
+the deterministic SECURITY ROLL-UP: for each group it reads the shared `security_findings` ledger and
+partitions this group's repos' findings into new (alerted in the last 7 days), still-open (carried),
+and resolved-this-week. No LLM — the plain-English finding text was written upstream by the Security
+chain; here we only count and list. This roll-up is the weekly "we watched, here is the state"
+reassurance that makes Security Watch's silence trustworthy, so it ships even in a quiet, no-code week.
+
+Output (additive, run-based): `digest_technical_reports = {slug: {repository_deep_dive, poem,
+security_rollup}}` consumed by send_digest. Flat script, no __main__ guard, no sibling imports.
+"""
+import json
+from datetime import datetime, timezone
+from typing import List, Dict, Any
+from pydantic import BaseModel, Field
+import waveassist
+
+waveassist.init()   # credits gated once upstream in digest_check_and_init
+
+print("GitZoid Digest: starting technical report generation (generate_technical_report) node")
+
+DEFAULT_MODEL = "anthropic/claude-sonnet-4.6"
+MAX_TOKENS = 6000
+TEMPERATURE = 0.4
+ROLLUP_WINDOW_DAYS = 7
+_SEV_RANK = {"critical": 0, "high": 1, "medium": 2, "low": 3, "unknown": 4}
+
+QUIET_POEM = [
+    "Quiet repos rest, untouched branches dreaming of merge lights",
+    "Product sleeps softly, backlog whispers promises for next sprint",
+    "Engineers sip coffee, plotting fresh commits for Monday",
+    "Calm before velocity, waiting for ideas to spark",
+]
+
+
+class RepoUpdate(BaseModel):
+    repo_name: str = Field(description="Repository name (owner/repo)")
+    status: str = Field(description="1-2 words for the repo's status (e.g. 'Heavy Refactor', 'Feature Dev')")
+    technical_changes: List[str] = Field(description="MAX 2-3 specific fixes/improvements in this repo")
+
+
+class TechnicalReport(BaseModel):
+    repository_deep_dive: List[RepoUpdate] = Field(description="Updates grouped by repository")
+    poem: List[str] = Field(description="4 lines, tech-focused, rhyming, each 6-10 words")
+
+
+# ---------------------------------------------------------------- pure helpers (tested)
+
+def filter_analyses(repository_analyses, group_repos):
+    s = set(group_repos or [])
+    return [a for a in (repository_analyses or []) if a.get("repository") in s]
+
+
+def count_changes(analyses):
+    return sum(len(a.get("changes", []) or []) for a in (analyses or []))
+
+
+def build_changes_context(analyses) -> str:
+    result = {a.get("repository", "Unknown"): a.get("changes", [])
+              for a in (analyses or []) if a.get("changes")}
+    return json.dumps(result, default=str, ensure_ascii=False, separators=(",", ":")) if result else ""
+
+
+def build_business_report_context(business_report) -> str:
+    if not business_report:
+        return ""
+    parts = ["The Business Report already summarised the headline features. "
+             "Focus on repository-specific technical details:"]
+    if business_report.get("executive_summary"):
+        parts.append(f"Executive Summary: {business_report['executive_summary']}")
+    if business_report.get("shipped_features"):
+        parts.append(f"Shipped Features: {json.dumps(business_report['shipped_features'], ensure_ascii=False)}")
+    return "\n".join(parts)
+
+
+def _within_days(iso, now, days) -> bool:
+    if not iso:
+        return False
+    try:
+        return (now - datetime.fromisoformat(iso)).total_seconds() <= days * 86400
+    except Exception:
+        return False
+
+
+def _slim(e, count=1):
+    # Dependency entries carry no human title; build a package+version label (a bare "django" with no
+    # version was the bug). count = how many advisories this grouped item represents.
+    if e.get("category") == "dependency":
+        title = f"{e.get('name') or ''} {e.get('version') or ''}".strip() or "dependency"
+    else:
+        title = e.get("title") or e.get("name") or e.get("category")
+    return {"title": title, "repo": e.get("repo"), "severity": e.get("severity"),
+            "actively_exploited": bool(e.get("actively_exploited")), "count": count}
+
+
+def _group_rollup_entries(entries):
+    """Group a bucket's entries the SAME way the alert email does: a dependency package
+    (repo, name, version) is ONE item (count = #advisories); code findings stay individual. This
+    keeps the digest's counts/list consistent with the alert (the '17 vs 6' class of bug)."""
+    groups, order = {}, []
+    for e in entries:
+        if e.get("category") == "dependency":
+            key = ("dep", e.get("repo"), e.get("name"), e.get("version"))
+        else:
+            key = ("code", e.get("sig") or id(e))
+        if key not in groups:
+            groups[key] = []
+            order.append(key)
+        groups[key].append(e)
+    items = []
+    for key in order:
+        g = groups[key]
+        worst = sorted(g, key=lambda x: _SEV_RANK.get(x.get("severity"), 4))[0]
+        items.append(_slim(worst, count=len(g)))
+    return items
+
+
+def security_rollup(ledger, group_repos, now, days=ROLLUP_WINDOW_DAYS):
+    """Partition this group's security findings into new (first alerted in the window), still-open
+    (carried from before), and resolved-this-week, then GROUP per package so the digest count matches
+    the alert. Deterministic; the finding text was written upstream."""
+    repos = set(group_repos or [])
+    new_e, open_e, res_e = [], [], []
+    for e in (ledger or {}).values():
+        if not isinstance(e, dict) or e.get("repo") not in repos:
+            continue
+        status = e.get("status")
+        if status == "open":
+            (new_e if _within_days(e.get("first_seen"), now, days) else open_e).append(e)
+        elif status == "resolved" and _within_days(e.get("resolved_at"), now, days):
+            res_e.append(e)
+
+    new = _group_rollup_entries(new_e)
+    still_open = _group_rollup_entries(open_e)
+    resolved = _group_rollup_entries(res_e)
+
+    def keyf(x):
+        return (0 if x["actively_exploited"] else 1, _SEV_RANK.get(x["severity"], 4))
+    new.sort(key=keyf)
+    still_open.sort(key=keyf)
+    resolved.sort(key=keyf)
+    return {"new": new, "still_open": still_open, "resolved": resolved,
+            "counts": {"new": len(new), "still_open": len(still_open), "resolved": len(resolved)}}
+
+
+def build_prompt(project_name, changes_context, business_report_context, brain_context) -> str:
+    parts = [
+        ("You are a technical advisor reporting to a busy CTO. "
+         f"Review the development activity for {project_name}. The Business Report already covered the big "
+         "features. Now go repository by repository and list the technical work that matters. "
+         "If a section has no significant updates, strictly return an empty list."),
+    ]
+    if business_report_context:
+        parts.append("\n<Business Report Context>\n" + business_report_context)
+    if brain_context:
+        parts.append("\n<Repo Context>\n" + brain_context)
+    if changes_context:
+        parts.append("\n*** PRIMARY SOURCE: Code Changes Summarized ***\n" + changes_context)
+    parts.append("""
+Create a repository-by-repository technical deep dive.
+
+CRITICAL INSTRUCTIONS:
+- Go through each repository that had activity and list what happened there.
+- Aggressively consolidate: do not list individual commits; group related changes.
+- Ignore trivia (typos, formatting, dependency bumps) unless a major version shift.
+- MAXIMUM 2-3 technical changes per repository.
+
+1. repository_deep_dive: one RepoUpdate per repository with activity (repo_name, status, technical_changes).
+2. poem: exactly 4 lines, each 6-10 words, tech-focused, rhyming, one connected poem.
+
+Plain prose in short sentences. Do NOT use em dashes, and do not use a hyphen as a connector between
+clauses. No emojis in the deep-dive text.""")
+    return "".join(parts)
+
+
+def brain_block(profiles_by_repo) -> str:
+    parts = []
+    for repo, profile in (profiles_by_repo or {}).items():
+        arch = ((profile or {}).get("architecture_summary") or "").strip()
+        if arch:
+            parts.append(f"- {repo}: {arch}")
+    return ("Repository context (from GitZoid's profile):\n" + "\n".join(parts)) if parts else ""
+
+
+# ---------------------------------------------------------------- driver (flat, fall-through)
+
+skip = waveassist.fetch_data("digest_skip_run", run_based=True, default="0") == "1"
+groups = [] if skip else (waveassist.fetch_data("digest_resolved_groups", run_based=True, default=[]) or [])
+
+if skip:
+    print("GitZoid Digest: digest_skip_run set; generate_technical_report no-op.")
+
+if groups:
+    repository_analyses = waveassist.fetch_data("repository_analyses", default=[]) or []
+    business_reports = waveassist.fetch_data("digest_business_reports", run_based=True, default={}) or {}
+    ledger = waveassist.fetch_data("security_findings", default={}) or {}
+    model_name = waveassist.fetch_data("model_name", default=DEFAULT_MODEL) or DEFAULT_MODEL
+    now = datetime.now(timezone.utc)
+
+    technical_reports = {}
+    for group in groups:
+        slug = group.get("slug")
+        name = group.get("name") or "your repositories"
+        repos = group.get("repos") or []
+        analyses = filter_analyses(repository_analyses, repos)
+        rollup = security_rollup(ledger, repos, now)
+
+        if count_changes(analyses) == 0:
+            # Quiet code week, but the security roll-up still ships the reassurance. No LLM needed.
+            technical_reports[slug] = {"repository_deep_dive": [], "poem": QUIET_POEM,
+                                       "security_rollup": rollup}
+            print(f"· {slug}: no code activity; security roll-up only "
+                  f"({rollup['counts']['new']} new, {rollup['counts']['resolved']} resolved)")
+            continue
+
+        profiles = {a["repository"]: (waveassist.fetch_data(f"profile:{a['repository']}", default={}) or {})
+                    for a in analyses if a.get("changes")}
+        prompt = build_prompt(name, build_changes_context(analyses),
+                              build_business_report_context(business_reports.get(slug) or {}),
+                              brain_block(profiles))
+        try:
+            result = waveassist.call_llm(model=model_name, prompt=prompt, response_model=TechnicalReport,
+                                         max_tokens=MAX_TOKENS, temperature=TEMPERATURE)
+        except Exception as e:
+            print(f"⚠️ technical LLM failed for {slug}: {e}")
+            result = None
+
+        if result:
+            report = result.model_dump(by_alias=True)
+            report["security_rollup"] = rollup
+            technical_reports[slug] = report
+            print(f"✓ {slug}: technical report generated")
+        else:
+            # LLM raised — NOT a quiet week. No fallback poem; flag so send_digest skips this group.
+            report = {"repository_deep_dive": [], "poem": [], "generation_failed": True,
+                      "security_rollup": rollup}
+            technical_reports[slug] = report
+            print(f"⚠️ {slug}: technical report generation FAILED (LLM error); flagged, no fallback poem")
+
+    waveassist.store_data("digest_technical_reports", technical_reports, run_based=True, data_type="json")
+    print(f"GitZoid Digest: technical reports for {len(technical_reports)} group(s).")

--- a/post_comment.py
+++ b/post_comment.py
@@ -71,13 +71,36 @@ def _verdict_line(verdict, n_find, n_opt, n_sugg):
 
 # ---------------------------------------------------------------- GitHub REST
 
+def create_single_review_comment(repo_path, pr_number, commit_id, comment, token):
+    """POST ONE inline review comment. Returns the json on success, None on failure. Used as the
+    per-comment fallback when the atomic batch review is rejected for one bad anchor."""
+    url = f"https://api.github.com/repos/{repo_path}/pulls/{pr_number}/comments"
+    payload = {"commit_id": commit_id, "path": comment.get("path"), "line": comment.get("line"),
+               "side": comment.get("side", "RIGHT"), "body": comment.get("body", "")}
+    resp = requests.post(url, headers=_gh_headers(token), json=payload, timeout=30)
+    if resp.status_code in (200, 201):
+        return resp.json()
+    print(f"❌ single comment failed HTTP {resp.status_code} "
+          f"({comment.get('path')}:{comment.get('line')}): {resp.text[:200]}")
+    return None
+
+
 def create_pr_review(repo_path, pr_number, commit_id, summary_body, inline_comments, token):
-    """POST one COMMENT review with inline comments. commit_id anchors the lines."""
+    """POST one COMMENT review with inline comments. commit_id anchors the lines. On a 422 (GitHub
+    rejects the WHOLE batch when any single line-anchor is stale), fall back to posting each comment
+    on its own so one bad anchor only loses itself, not every inline comment."""
     url = f"https://api.github.com/repos/{repo_path}/pulls/{pr_number}/reviews"
     payload = {"commit_id": commit_id, "event": "COMMENT", "body": summary_body or "", "comments": inline_comments}
     resp = requests.post(url, headers=_gh_headers(token), json=payload, timeout=30)
     if resp.status_code in (200, 201):
         return resp.json()
+    if resp.status_code == 422 and inline_comments:
+        print("⚠️ atomic review rejected HTTP 422; falling back to per-comment posting.")
+        posted = sum(1 for c in inline_comments
+                     if create_single_review_comment(repo_path, pr_number, commit_id, c, token))
+        if posted:
+            return {"id": None, "_fallback": True, "_posted": posted}
+        return None
     print(f"❌ create review failed HTTP {resp.status_code}: {resp.text[:300]}")
     return None
 
@@ -119,7 +142,9 @@ def findings_to_inline_comments(findings):
     for f in (findings or []):
         if f.get("line") is None:            # unanchored → summary-only, never an inline comment
             continue
-        body = _finding_header(f) + "\n\n" + f.get("body", "")
+        if not f.get("path"):                # no file → cannot anchor; a falsy path 422s the whole batch
+            continue
+        body = _finding_header(f) + "\n\n" + (f.get("body") or "")
         if f.get("suggested_replacement"):
             body += f"\n\n```suggestion\n{f['suggested_replacement']}\n```"
         out.append({"path": f.get("path"), "line": f.get("line"), "side": f.get("side", "RIGHT"), "body": body})
@@ -131,12 +156,14 @@ def findings_to_inline_comments(findings):
 def _finding_row(v, resolved=False):
     """One clean line: no per-line emoji. Section header carries the icon; severity stays as
     text on open issues for quick triage. Resolved rows drop severity entirely."""
-    loc = f"`{v.get('path')}:{v.get('line')}`" if v.get("line") is not None else f"`{v.get('path')}`"
+    path = v.get("path") or ""
+    body = v.get("body") or ""
+    loc = f"`{path}:{v.get('line')}`" if v.get("line") is not None else f"`{path}`"
     if resolved:
-        return f"- {loc} — {v.get('body')}"
+        return f"- {loc} — {body}"
     sev = v.get("severity")
     sev_md = f"_{sev}_ " if sev in ("high", "medium", "low") else ""
-    return f"- {sev_md}{loc} — {v.get('body')}"
+    return f"- {sev_md}{loc} — {body}"
 
 
 def build_summary_md(review, findings_ledger, changed_files, sha_short, current_sha=None, is_update=False):
@@ -151,6 +178,11 @@ def build_summary_md(review, findings_ledger, changed_files, sha_short, current_
     free_opts = review.get("potential_optimizations") or []
     free_sugg = review.get("suggestions") or []
     summary_pts = review.get("summary") or review.get("changes_summary") or []
+    # A null-filled LLM result or a legacy ledger can hand back a string/None/scalar instead of a
+    # list of strings; coerce so the render never iterates characters or prints a literal "None".
+    if isinstance(summary_pts, str):
+        summary_pts = [summary_pts]
+    summary_pts = [str(s) for s in summary_pts if s is not None] if isinstance(summary_pts, (list, tuple)) else []
     n_opt = len(opt_f) + len(free_opts)
     n_sug = len(sug_f) + len(free_sugg)
 
@@ -257,92 +289,74 @@ def update_reviewed_prs(reviewed_prs, repo_path, pr_number, current_sha, review_
     reviewed_prs[pr_key] = entry
 
 
-# ---------------------------------------------------------------- driver (flat, fall-through)
+# ---------------------------------------------------------------- per-PR work (isolated)
 
-prs_to_review = waveassist.fetch_data("pull_requests", default=[]) or []
-should_process = any(pr.get("comment_generated") and not pr.get("comment_posted") for pr in prs_to_review)
+def process_one_pr(pr, reviewed_prs, access_token, preview):
+    """Post the review + summary for ONE pr. Returns (changed, posted_url, html_block). In preview
+    mode it posts nothing and returns the preview block. A raise here is caught by run_driver's loop
+    so one malformed PR (bad field, network blip) never sinks the rest of the batch."""
+    if not pr.get("comment_generated") or pr.get("comment_posted"):
+        return False, None, None
+    review_dict = pr.get("review_dict") or {}
+    if not review_dict:
+        return False, None, None
+    repo_path = pr.get("id")
+    pr_number = pr.get("pr_number")
+    current_sha = pr.get("current_sha", "")
+    sha_short = current_sha[:7]
+    entry = reviewed_prs.get(f"{repo_path}#{pr_number}", {})
+    # Re-key by the current finding_sig so a signature-format change across upgrades is transparent.
+    prior_ledger = rekey_ledger(entry.get("findings", {}))
+    summary_comment_id = entry.get("summary_comment_id")
+    if summary_comment_id is None and not preview:   # idempotent: reuse our marked comment, never duplicate
+        summary_comment_id = find_summary_comment_id(repo_path, pr_number, access_token)
 
-if should_process:
-    access_token = waveassist.fetch_data("github_access_token", default="") or ""
-    reviewed_prs = waveassist.fetch_data("reviewed_prs", default={}) or {}
-    preview = waveassist.is_test_run()
-    display = "<div style=\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; padding: 16px; line-height: 1.5;\">"
-    posted_links = []
-    reviewed_prs_changed = False
+    gated = review_dict.get("findings", [])
+    is_update = bool(summary_comment_id)
+    new_ledger, inline_comments = reconcile_ledger(prior_ledger, gated, current_sha, is_update=is_update)
+    changed_files = sorted({f.get("path") for f in gated if f.get("path")})
+    summary_md = build_summary_md(review_dict, new_ledger, changed_files, sha_short,
+                                  current_sha=current_sha, is_update=is_update)
 
-    for pr in prs_to_review:
-        if not pr.get("comment_generated") or pr.get("comment_posted"):
-            continue
-        review_dict = pr.get("review_dict") or {}
-        if not review_dict:
-            continue
-        repo_path = pr.get("id")
-        pr_number = pr.get("pr_number")
-        current_sha = pr.get("current_sha", "")
-        sha_short = current_sha[:7]
-        entry = reviewed_prs.get(f"{repo_path}#{pr_number}", {})
-        # Re-key by the current finding_sig so a signature-format change across upgrades is transparent.
-        prior_ledger = rekey_ledger(entry.get("findings", {}))
-        summary_comment_id = entry.get("summary_comment_id")
-        if summary_comment_id is None and not preview:   # idempotent: reuse our marked comment, never duplicate
-            summary_comment_id = find_summary_comment_id(repo_path, pr_number, access_token)
+    if preview:
+        block = (
+            f'<div style="margin-bottom:8px;color:#b26a00;">• <strong>PREVIEW</strong> — would post to '
+            f'<strong>{html.escape(str(repo_path))}</strong> PR #{pr_number} ({len(inline_comments)} inline). No write.</div>'
+            f'<details><summary>Summary preview</summary><pre style="white-space:pre-wrap;font-size:12px;">'
+            f'{html.escape(summary_md)}</pre></details>')
+        return False, None, block
 
-        gated = review_dict.get("findings", [])
-        is_update = bool(summary_comment_id)
-        new_ledger, inline_comments = reconcile_ledger(prior_ledger, gated, current_sha, is_update=is_update)
-        changed_files = sorted({f.get("path") for f in gated if f.get("path")})
-        summary_md = build_summary_md(review_dict, new_ledger, changed_files, sha_short,
-                                      current_sha=current_sha, is_update=is_update)
+    review = None
+    if inline_comments:                                   # never POST an empty review
+        review = create_pr_review(repo_path, pr_number, current_sha, "", inline_comments, access_token)
+    if summary_comment_id:
+        result = edit_summary_comment(repo_path, summary_comment_id, summary_md, access_token)
+        cid = summary_comment_id
+        label = "Updated"
+    else:
+        summary = create_summary_comment(repo_path, pr_number, summary_md, access_token)
+        result = summary
+        cid = summary.get("id") if summary else None
+        label = "Full"
 
-        if preview:
-            display += (
-                f'<div style="margin-bottom:8px;color:#b26a00;">• <strong>PREVIEW</strong> — would post to '
-                f'<strong>{html.escape(str(repo_path))}</strong> PR #{pr_number} ({len(inline_comments)} inline). No write.</div>'
-                f'<details><summary>Summary preview</summary><pre style="white-space:pre-wrap;font-size:12px;">'
-                f'{html.escape(summary_md)}</pre></details>')
-            continue
+    if not result and not review:
+        return False, None, None        # nothing posted at all → retry the whole PR next cycle (no dup)
 
-        review = None
-        if inline_comments:                                   # never POST an empty review
-            review = create_pr_review(repo_path, pr_number, current_sha, "", inline_comments, access_token)
-        if summary_comment_id:
-            result = edit_summary_comment(repo_path, summary_comment_id, summary_md, access_token)
-            cid = summary_comment_id
-            label = "Updated"
-        else:
-            summary = create_summary_comment(repo_path, pr_number, summary_md, access_token)
-            result = summary
-            cid = summary.get("id") if summary else None
-            label = "Full"
-
-        if result:
-            pr["comment_posted"] = True
-            update_reviewed_prs(reviewed_prs, repo_path, pr_number, current_sha, review_text=summary_md,
-                                summary_comment_id=cid, review_id=(review or {}).get("id"),
-                                findings_ledger=new_ledger)
-            reviewed_prs_changed = True
-            pr["files"] = []                                  # clear patches after the ledger has anchors
-            url = result.get("html_url") or f"https://github.com/{repo_path}/pull/{pr_number}"
-            display += (
-                f'<div style="margin-bottom: 8px; color: #28a745;">• {label} review posted to '
-                f'<strong>{html.escape(str(repo_path))}</strong> PR #{pr_number}. '
-                f'<a href="{html.escape(url, quote=True)}" target="_blank" rel="noopener noreferrer" '
-                f'style="{OUTPUT_LINK_STYLE}">View on GitHub</a></div>')
-            posted_links.append(url)
-
-    if posted_links:
-        display += (f'<div style="margin-top: 10px;"><span style="{OUTPUT_URL_HINT_STYLE}">'
-                    f"If links do not open in this view, copy a URL below.</span></div>")
-        for u in posted_links:
-            display += f'<span style="{OUTPUT_URL_SELECT_STYLE}">{html.escape(u)}</span>'
-    display += "</div>"
-
-    if not preview:
-        if reviewed_prs_changed:
-            waveassist.store_data("reviewed_prs", reviewed_prs, data_type="json")
-        waveassist.store_data("pull_requests", [], data_type="json")
-    waveassist.store_data("display_output", {"html_content": display}, run_based=True, data_type="json")
-    print(f"✅ post_comment done (preview={preview}, posted={len(posted_links)}).")
+    # Record the ledger as soon as ANYTHING posted, so already-posted inline comments are never
+    # re-posted as "new" on a later run — even if the summary comment failed this run.
+    update_reviewed_prs(reviewed_prs, repo_path, pr_number, current_sha, review_text=summary_md,
+                        summary_comment_id=cid, review_id=(review or {}).get("id"),
+                        findings_ledger=new_ledger)
+    if result:
+        pr["comment_posted"] = True                       # fully done only when the summary is up too
+        pr["files"] = []                                  # clear patches after the ledger has anchors
+    url = (result or {}).get("html_url") or f"https://github.com/{repo_path}/pull/{pr_number}"
+    block = (
+        f'<div style="margin-bottom: 8px; color: #28a745;">• {label} review posted to '
+        f'<strong>{html.escape(str(repo_path))}</strong> PR #{pr_number}. '
+        f'<a href="{html.escape(url, quote=True)}" target="_blank" rel="noopener noreferrer" '
+        f'style="{OUTPUT_LINK_STYLE}">View on GitHub</a></div>')
+    return True, url, block
 
 
 def release_run_lock():
@@ -350,8 +364,8 @@ def release_run_lock():
     it (token match). `run_lock_token` is run-based, so it MUST be read run-based here, matching
     how check_credits_and_init writes it — only the acquiring run reads back its own token; a
     skipped/overlapping cycle never wrote one, so under its own run id it reads "" and bails out,
-    and can never free the holder's lock. As the last node in the DAG, reaching here means the run
-    is done; a crashed run leaves the lock to expire via its TTL instead."""
+    and can never free the holder's lock. Called from run_driver's finally so the lock is freed even
+    if the run crashes mid-way (instead of waiting out the TTL)."""
     my_token = waveassist.fetch_data("run_lock_token", run_based=True, default="") or ""
     if not my_token:
         return  # this cycle didn't acquire the lock (skip or crash) — nothing to release
@@ -361,4 +375,50 @@ def release_run_lock():
         print("GitZoid: released run lock.")
 
 
-release_run_lock()
+# ---------------------------------------------------------------- driver (flat, fall-through)
+
+def run_driver():
+    """Post reviews for every generated-but-unposted PR. Each PR is isolated (one bad PR never sinks
+    the rest), and the run-lock is released in a finally so a crash anywhere never leaks it."""
+    prs_to_review = waveassist.fetch_data("pull_requests", default=[]) or []
+    should_process = any(pr.get("comment_generated") and not pr.get("comment_posted") for pr in prs_to_review)
+    try:
+        if should_process:
+            access_token = waveassist.fetch_data("github_access_token", default="") or ""
+            reviewed_prs = waveassist.fetch_data("reviewed_prs", default={}) or {}
+            preview = waveassist.is_test_run()
+            display = "<div style=\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; padding: 16px; line-height: 1.5;\">"
+            posted_links = []
+            reviewed_prs_changed = False
+
+            for pr in prs_to_review:
+                try:
+                    changed, url, block = process_one_pr(pr, reviewed_prs, access_token, preview)
+                except Exception as e:
+                    print(f"❌ post_comment: PR #{pr.get('pr_number')} ({pr.get('id')}) failed: {e}")
+                    continue
+                if block:
+                    display += block
+                if changed:
+                    reviewed_prs_changed = True
+                if url:
+                    posted_links.append(url)
+
+            if posted_links:
+                display += (f'<div style="margin-top: 10px;"><span style="{OUTPUT_URL_HINT_STYLE}">'
+                            f"If links do not open in this view, copy a URL below.</span></div>")
+                for u in posted_links:
+                    display += f'<span style="{OUTPUT_URL_SELECT_STYLE}">{html.escape(u)}</span>'
+            display += "</div>"
+
+            if not preview:
+                if reviewed_prs_changed:
+                    waveassist.store_data("reviewed_prs", reviewed_prs, data_type="json")
+                waveassist.store_data("pull_requests", [], data_type="json")
+            waveassist.store_data("display_output", {"html_content": display}, run_based=True, data_type="json")
+            print(f"✅ post_comment done (preview={preview}, posted={len(posted_links)}).")
+    finally:
+        release_run_lock()
+
+
+run_driver()

--- a/scan_dependencies.py
+++ b/scan_dependencies.py
@@ -444,25 +444,27 @@ def collect_repo_dependencies(repo_path, branch, headers):
 
 
 def query_osv(deps):
-    """OSV querybatch → {(name,version): [vuln_id,...]} then hydrate each id to a full record."""
+    """OSV querybatch → ({(name,version): [vuln_id,...]}, ok). `ok` is False ONLY when the OSV call
+    itself failed (HTTP error / exception), so the driver can tell a clean scan ({} , True) from a
+    feed hiccup ({}, False) and never resolve a finding just because a hiccup made it absent."""
     batch = build_osv_batch(deps)
     if not batch["queries"]:
-        return {}
+        return {}, True            # nothing to query is a successful (clean) scan
     try:
         r = requests.post(OSV_BATCH_URL, json=batch, timeout=HTTP_TIMEOUT)
         if r.status_code != 200:
             print(f"⚠️ OSV batch HTTP {r.status_code}")
-            return {}
+            return {}, False
         results = r.json().get("results", [])
     except Exception as e:
         print(f"⚠️ OSV batch failed: {e}")
-        return {}
+        return {}, False
     out = {}
     for dep, res in zip(deps, results):
         ids = [v.get("id") for v in (res.get("vulns") or []) if v.get("id")]
         if ids:
             out[(dep["name"], dep["version"])] = ids
-    return out
+    return out, True
 
 
 def hydrate_vuln(vuln_id):
@@ -487,6 +489,28 @@ def fetch_kev_set():
     return set()      # soft-fail: no KEV data just means no auto-escalation this run
 
 
+def fetch_kev_set_with_status():
+    """Like fetch_kev_set but also reports whether the feed call succeeded. When KEV fails we can't
+    trust actively_exploited=False, so the driver treats the whole run as degraded (no repo is marked
+    scanned-ok) and carries findings forward instead of resolving them."""
+    try:
+        r = requests.get(KEV_URL, timeout=HTTP_TIMEOUT)
+        if r.status_code == 200:
+            return parse_kev_feed(r.json()), True
+        print(f"⚠️ KEV HTTP {r.status_code}")
+    except Exception as e:
+        print(f"⚠️ KEV fetch failed: {e}")
+    return set(), False
+
+
+def _dep_sig(repo, name, vuln_id):
+    """Dependency finding identity — MUST match triage_and_alert.finding_sig for a dependency
+    (no dedup_key): category|repo|name|vuln_id. Used to look a finding up in the persistent ledger so
+    its realism verdict is reused instead of re-judged by a non-deterministic LLM every run."""
+    raw = f"dependency|{repo}|{name}|{vuln_id}"
+    return hashlib.sha1(raw.encode()).hexdigest()[:12]
+
+
 # ---------------------------------------------------------------- driver (flat, fall-through)
 
 skip = waveassist.fetch_data("security_skip_run", run_based=True, default="0") == "1"
@@ -499,8 +523,10 @@ if repositories:
     access_token = waveassist.fetch_data("github_access_token", default="") or ""
     model_name = waveassist.fetch_data("model_name", default=DEFAULT_MODEL) or DEFAULT_MODEL
     headers = _gh_headers(access_token)
-    kev_set = fetch_kev_set()
+    kev_set, kev_ok = fetch_kev_set_with_status()
+    prior_ledger = waveassist.fetch_data("security_findings", default={}) or {}
     candidates = []
+    scanned_ok = set()
 
     for repo in repositories:
         repo_path = repo.get("id") if isinstance(repo, dict) else repo
@@ -522,7 +548,7 @@ if repositories:
                 print(f"✓ {repo_path}: lockfiles unchanged since a clean scan; skip")
                 continue
 
-            osv_hits = query_osv(deps)
+            osv_hits, osv_ok = query_osv(deps)
             repo_findings = []
             for (name, version), vuln_ids in osv_hits.items():
                 reach = dep_reachability(name, profile)
@@ -543,6 +569,15 @@ if repositories:
                     }
                     if not passes_feed_gate(finding):
                         continue
+                    # Realism is decided ONCE. If we already judged this finding real (it is open in
+                    # the ledger), reuse that verdict and impact instead of re-running a
+                    # non-deterministic LLM every day — a daily flip is what made the same dependency
+                    # silently resolve then re-alert (issue #1).
+                    cached = prior_ledger.get(_dep_sig(repo_path, name, parsed["id"]))
+                    if isinstance(cached, dict) and cached.get("status") == "open":
+                        finding["impact"] = cached.get("impact") or ""
+                        repo_findings.append(finding)
+                        continue
                     is_real, impact = assess_finding(model_name, finding, profile)
                     if not is_real:
                         print(f"· dropped {name} {parsed['id']} (model: not a realistic risk)")
@@ -551,8 +586,14 @@ if repositories:
                     repo_findings.append(finding)
 
             candidates.extend(repo_findings)
+            # Mark the repo scanned-ok only when BOTH feeds were healthy this run; a hiccup must never
+            # look like "the issue is gone", so on a degraded run the repo stays out of scanned_ok and
+            # triage carries its findings forward instead of resolving them.
+            if osv_ok and kev_ok:
+                scanned_ok.add(repo_path)
             waveassist.store_data(f"dependency_snapshot:{repo_path}",
-                                  {"hash": blob_hash, "scanned_clean": len(repo_findings) == 0,
+                                  {"hash": blob_hash,
+                                   "scanned_clean": osv_ok and kev_ok and len(repo_findings) == 0,
                                    "deps": deps},
                                   data_type="json")
             print(f"✓ {repo_path}: scanned {len(deps)} deps, {len(repo_findings)} real finding(s)")
@@ -563,5 +604,12 @@ if repositories:
     # Hand candidates to triage (run-based; deep_security_audit appends to the same key next).
     existing = waveassist.fetch_data("security_candidates", run_based=True, default=[]) or []
     waveassist.store_data("security_candidates", existing + candidates,
+                          run_based=True, data_type="json")
+    # Publish the repos whose DEPENDENCIES were scanned successfully this run. triage uses this to
+    # resolve only dependency findings (code findings resolve against security_scanned_ok_code, which
+    # the weekly deep audit writes) — so a daily dep scan never silently resolves an un-audited auth
+    # hole. Merge in case of re-entry.
+    prior_ok = set(waveassist.fetch_data("security_scanned_ok_deps", run_based=True, default=[]) or [])
+    waveassist.store_data("security_scanned_ok_deps", sorted(prior_ok | scanned_ok),
                           run_based=True, data_type="json")
     print(f"GitZoid Security: scan_dependencies produced {len(candidates)} candidate(s).")

--- a/send_digest.py
+++ b/send_digest.py
@@ -105,16 +105,21 @@ def render_security_rollup_html(rollup) -> str:
     return f"<h2>🔒 SECURITY</h2>{body}"
 
 
+def digest_title(group_name, implicit=False) -> str:
+    """Brand title shared by the inbox SUBJECT and the email H1 so the two always match. Unnamed/
+    implicit -> "GitZoid Digest"; a named group reads as "GitZoid <name> Digest". The bare
+    "All repositories" default is never surfaced."""
+    name = (group_name or "").strip()
+    if implicit or not name or name == "All repositories":
+        return "GitZoid Digest"
+    return f"GitZoid {name} Digest"
+
+
 def build_subject(group_name, period_end="", implicit=False) -> str:
     """Branded subject in the same shape as the security alert ("GitZoid Security: ..."):
-    "GitZoid Digest: Week of <date>" for the implicit/unnamed single group; a named group is inserted
-    before the week. The bare "All repositories" default is never surfaced. Plain text."""
+    "GitZoid <name> Digest: Week of <date>" (or just "GitZoid Digest:" when unnamed)."""
     week = f"Week of {period_end}" if period_end else "Weekly update"
-    name = (group_name or "").strip()
-    # The project name reads as part of the brand phrase: "GitZoid Sacred Walks Digest" — nicer than
-    # tacking it on after an em dash. No name configured -> just "GitZoid Digest".
-    brand = "GitZoid Digest" if (implicit or not name or name == "All repositories") else f"GitZoid {name} Digest"
-    return f"{brand}: {week}"
+    return f"{digest_title(group_name, implicit)}: {week}"
 
 
 def group_generation_failed(business_report, technical_report) -> bool:
@@ -165,8 +170,8 @@ li { margin: 4px 0; line-height: 1.45; }
 
 
 def build_email_html(group_name, business_report, technical_report, stats, date_range, implicit=False) -> str:
-    """The combined per-group digest email (also rendered to PDF). The H1 is the stable brand title
-    "Knowledge Digest"; a named, non-implicit group's label becomes the scope subtitle below it."""
+    """The combined per-group digest email (also rendered to PDF). The H1 matches the inbox subject's
+    brand title (digest_title): "GitZoid <name> Digest" for a named group, "GitZoid Digest" unnamed."""
     business_report = business_report or {}
     technical_report = technical_report or {}
     summary = business_report.get("executive_summary", "No summary available.")
@@ -193,8 +198,6 @@ def build_email_html(group_name, business_report, technical_report, stats, date_
         # found" line otherwise runs straight into the poem).
         poem_divider = "<hr style='border:0;border-top:1px solid #e5e7eb;margin:22px 0' />"
 
-    name = (group_name or "").strip()
-    scope = "" if (implicit or not name or name == "All repositories") else f"<div class='subtitle'>{_esc(name)}</div>"
     period = ""
     if date_range and date_range.get("start_date_formatted"):
         period = (f"<div class='subtitle'>Report period: {_esc(date_range.get('start_date_formatted'))} - "
@@ -202,7 +205,7 @@ def build_email_html(group_name, business_report, technical_report, stats, date_
 
     return f"""<html><head><meta charset="utf-8" /><style>{_STYLE}</style></head><body>
 <div class="container">
-  <div class="header"><h1>Knowledge Digest</h1>{scope}{period}</div>
+  <div class="header"><h1>{_esc(digest_title(group_name, implicit))}</h1>{period}</div>
   <table class="stats-bar" role="presentation" cellpadding="0" cellspacing="0" width="100%"><tr>
     <td><div class="stat-value">{stats.get('commits', 0)}</div><div class="stat-label">Commits</div></td>
     <td><div class="stat-value">{stats.get('contributors', 0)}</div><div class="stat-label">Contributors</div></td>

--- a/send_digest.py
+++ b/send_digest.py
@@ -106,14 +106,15 @@ def render_security_rollup_html(rollup) -> str:
 
 
 def build_subject(group_name, period_end="", implicit=False) -> str:
-    """Branded subject: brand + week. The implicit/unnamed single group reads as "Your GitZoid digest";
-    a named group is prefixed with its label. The bare "All repositories" default is never surfaced.
-    Plain text. The em dash here is the separator only (not a clause connector)."""
-    week = f"week of {period_end}" if period_end else "weekly update"
+    """Branded subject in the same shape as the security alert ("GitZoid Security: ..."):
+    "GitZoid Digest: Week of <date>" for the implicit/unnamed single group; a named group is inserted
+    before the week. The bare "All repositories" default is never surfaced. Plain text."""
+    week = f"Week of {period_end}" if period_end else "Weekly update"
     name = (group_name or "").strip()
-    if implicit or not name or name == "All repositories":
-        return f"Your GitZoid digest — {week}"
-    return f"{name} — GitZoid digest — {week}"
+    # The project name reads as part of the brand phrase: "GitZoid Sacred Walks Digest" — nicer than
+    # tacking it on after an em dash. No name configured -> just "GitZoid Digest".
+    brand = "GitZoid Digest" if (implicit or not name or name == "All repositories") else f"GitZoid {name} Digest"
+    return f"{brand}: {week}"
 
 
 def group_generation_failed(business_report, technical_report) -> bool:

--- a/send_digest.py
+++ b/send_digest.py
@@ -1,0 +1,317 @@
+"""
+send_digest.py — the Knowledge Digest chain's delivery node (node 6, per group).
+
+Adapted from GitDigest's send_emails: the same combined HTML email (stats bar, summary, primary
+updates, repository deep dive, poem) plus a WeasyPrint PDF attachment, but fanned out PER resolved
+group. Each group's email goes to the account owner (always primary, via the SDK) with the group's
+configured recipients CC'd, and carries the group's SECURITY ROLL-UP — the weekly reassurance that
+makes Security Watch's silence trustworthy. The digest sends every week, even a quiet one.
+
+As the chain's last node it releases `digest_run_lock`, token-matched (only if this run owns it),
+exactly like triage_and_alert.
+
+WeasyPrint is imported lazily inside generate_pdf so the module loads without it and PDF generation
+soft-fails to "no attachment" rather than crashing the send. Flat script, no __main__ guard, no
+sibling imports.
+"""
+import io
+import html as html_lib
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+import waveassist
+
+waveassist.init()   # credits gated once upstream in digest_check_and_init
+
+print("GitZoid Digest: starting digest delivery (send_digest) node")
+
+RUN_LOCK_KEY = "digest_run_lock"
+_SEV_LABEL = {"critical": "Critical", "high": "High", "medium": "Medium", "low": "Low", "unknown": "Unknown"}
+
+
+def _esc(value) -> str:
+    return html_lib.escape(str(value), quote=True) if value is not None else ""
+
+
+def _ul(items) -> str:
+    if not items:
+        return "<p class='muted'>None this week.</p>"
+    return "<ul>" + "".join(f"<li>{_esc(i)}</li>" for i in items) + "</ul>"
+
+
+# ---------------------------------------------------------------- pure helpers (tested)
+
+def compute_stats(activity, group_repos) -> Dict[str, int]:
+    """Commits, distinct contributors, total + active repos — scoped to this group's repos."""
+    repos = set(group_repos or [])
+    commits, contributors, active = 0, set(), 0
+    for repo, data in (activity or {}).items():
+        if repo not in repos:
+            continue
+        cs = (data or {}).get("commits", []) or []
+        if cs:
+            active += 1
+        commits += len(cs)
+        for c in cs:
+            if c.get("author"):
+                contributors.add(c["author"])
+    return {"commits": commits, "contributors": len(contributors),
+            "total_repos": len(repos), "active_repos": active}
+
+
+def clean_recipients(recipients) -> List[str]:
+    """Validated CC list (the owner is always the primary recipient, added by the SDK)."""
+    out = []
+    for e in (recipients or []):
+        e = str(e).strip()
+        if "@" in e and "." in e.split("@")[-1]:
+            out.append(e)
+    return out
+
+
+def digest_status(sent, attempted):
+    """'success' ONLY if at least one group was attempted and every attempt delivered. If groups
+    existed but all were skipped because report generation failed upstream (attempted == 0), that's a
+    failure, not a silent green run."""
+    if attempted == 0:
+        return "generation_failed"
+    return "success" if sent == attempted else "email_failed"
+
+
+def render_security_rollup_html(rollup) -> str:
+    """The 'we watched, here is the state' section. Always rendered, even at zero (that IS the value)."""
+    rollup = rollup or {}
+    counts = rollup.get("counts", {"new": 0, "still_open": 0, "resolved": 0})
+
+    def line(item):
+        kev = " <span class='kev'>actively exploited</span>" if item.get("actively_exploited") else ""
+        sev = _SEV_LABEL.get(item.get("severity"), "")
+        n = item.get("count", 1)
+        adv = f", {n} advisories" if n and n > 1 else ""
+        return (f"<li><b>{_esc(item.get('title'))}</b> "
+                f"<span class='muted'>({_esc(item.get('repo'))}{', ' + sev if sev else ''}{adv})</span>{kev}</li>")
+
+    if not (counts.get("new") or counts.get("still_open") or counts.get("resolved")):
+        body = ("<p class='success'>No security issues found this week. GitZoid watched your dependencies "
+                "and code and found nothing exploitable.</p>")
+    else:
+        body = (f"<p class='muted'>{counts.get('new', 0)} new, {counts.get('still_open', 0)} still open, "
+                f"{counts.get('resolved', 0)} resolved this week.</p>")
+        if rollup.get("new"):
+            body += "<h3>New this week</h3><ul>" + "".join(line(i) for i in rollup["new"]) + "</ul>"
+        if rollup.get("still_open"):
+            body += "<h3>Still open</h3><ul>" + "".join(line(i) for i in rollup["still_open"]) + "</ul>"
+        if rollup.get("resolved"):
+            body += "<h3>Resolved this week</h3><ul>" + "".join(line(i) for i in rollup["resolved"]) + "</ul>"
+    return f"<h2>🔒 SECURITY</h2>{body}"
+
+
+def build_subject(group_name, period_end="", implicit=False) -> str:
+    """Branded subject: brand + week. The implicit/unnamed single group reads as "Your GitZoid digest";
+    a named group is prefixed with its label. The bare "All repositories" default is never surfaced.
+    Plain text. The em dash here is the separator only (not a clause connector)."""
+    week = f"week of {period_end}" if period_end else "weekly update"
+    name = (group_name or "").strip()
+    if implicit or not name or name == "All repositories":
+        return f"Your GitZoid digest — {week}"
+    return f"{name} — GitZoid digest — {week}"
+
+
+def group_generation_failed(business_report, technical_report) -> bool:
+    """True iff an LLM call RAISED while generating this group's report (set by the report nodes).
+    A deterministic quiet-week empty report does NOT set this flag, so a quiet group still sends."""
+    return bool((business_report or {}).get("generation_failed")
+                or (technical_report or {}).get("generation_failed"))
+
+
+def pdf_filename(group_name, now=None) -> str:
+    now = now or datetime.now(timezone.utc)
+    safe = "".join(c if c.isalnum() else "_" for c in (group_name or "digest"))
+    return f"GitZoid_Digest_{safe}_{now.strftime('%Y%m%d_%H%M')}.pdf"
+
+
+_STYLE = """
+body { font-family: Inter, -apple-system, BlinkMacSystemFont, "Helvetica Neue", Arial, sans-serif; color: #0f172a; margin: 18px; }
+.container { max-width: 700px; margin: 0 auto; background: #fff; border-radius: 12px; border: 1px solid #e5e7eb; border-top: 4px solid #1ED66C; overflow: hidden; }
+.header { padding: 14px; border-bottom: 1px solid #e5e7eb; }
+.header h1 { margin: 0; font-size: 22px; color: #0f1116; }
+.subtitle { color: #6b7280; font-size: 12px; margin-top: 6px; }
+/* Table, not flexbox: WeasyPrint (PDF) and email clients render flex unreliably and wrap the 4 stats;
+   a 4-column table keeps them on one row everywhere. */
+.stats-bar { width: 100%; border-collapse: collapse; border-bottom: 1px solid #e5e7eb; }
+.stats-bar td { width: 25%; text-align: center; padding: 16px 6px; vertical-align: top; }
+.stat-value { font-size: 24px; font-weight: 700; color: #1ED66C; }
+.stat-label { font-size: 11px; color: #6b7280; text-transform: uppercase; letter-spacing: 0.5px; }
+.content { padding: 14px; }
+h2 { color: #0f1116; font-size: 20px; margin-top: 28px; padding: 10px 0 10px 12px; border-left: 4px solid #1ED66C; border-bottom: 1px solid #e5e7eb; }
+h2:first-child { margin-top: 0; }
+h3 { color: #0f1116; font-size: 14px; margin: 14px 0 8px 0; }
+h4 { color: #0f1116; font-size: 14px; margin: 0 0 4px 0; }
+p { margin: 8px 0; line-height: 1.45; }
+ul { margin: 6px 0 10px 18px; padding: 0; }
+li { margin: 4px 0; line-height: 1.45; }
+.summary-box { padding: 12px; border-radius: 8px; border: 1px solid #e5e7eb; border-left: 3px solid #1ED66C; margin-bottom: 20px; }
+.repo-card { padding: 12px; border-radius: 12px; border: 1px solid #e5e7eb; border-left: 3px solid #1ED66C; margin: 10px 0; }
+.repo-status { color: #6b7280; font-weight: normal; font-size: 12px; }
+.muted { color: #6b7280; font-size: 12px; }
+.success { color: #148F47; font-weight: 500; }
+.kev { color: #b91c1c; font-weight: 600; font-size: 12px; }
+.poem { background: #f9fafb; padding: 16px; border-radius: 8px; border-left: 3px solid #1ED66C; margin: 20px 0; }
+.poem-line { margin: 2px 0; color: #374151; font-style: italic; }
+.footer { text-align: center; padding: 20px; border-top: 1px solid #e5e7eb; }
+.footer p { margin: 4px 0; font-size: 12px; color: #6b7280; }
+@page { margin: 0.75in; size: letter; }
+"""
+
+
+def build_email_html(group_name, business_report, technical_report, stats, date_range, implicit=False) -> str:
+    """The combined per-group digest email (also rendered to PDF). The H1 is the stable brand title
+    "Knowledge Digest"; a named, non-implicit group's label becomes the scope subtitle below it."""
+    business_report = business_report or {}
+    technical_report = technical_report or {}
+    summary = business_report.get("executive_summary", "No summary available.")
+    features = business_report.get("shipped_features", []) or []
+    deep_dive = technical_report.get("repository_deep_dive", []) or []
+    poem = [l for l in (technical_report.get("poem", []) or []) if l]
+    rollup_html = render_security_rollup_html(technical_report.get("security_rollup"))
+
+    repo_html = ""
+    for ru in deep_dive:
+        if isinstance(ru, dict):
+            repo_html += (f"<div class='repo-card'><h4>{_esc(ru.get('repo_name', 'Unknown'))} "
+                          f"<span class='repo-status'>({_esc(ru.get('status', ''))})</span></h4>"
+                          f"{_ul(ru.get('technical_changes', []))}</div>")
+    if not repo_html:
+        repo_html = "<p class='muted'>No repository updates this week.</p>"
+
+    poem_html = ""
+    poem_divider = ""
+    if poem:
+        poem_html = ("<div class='poem'><h3>A small poem for this week:</h3><em>"
+                     + "".join(f"<p class='poem-line'>{_esc(l)}</p>" for l in poem) + "</em></div>")
+        # Separate the poem from the security section above it (on a clean week the short "nothing
+        # found" line otherwise runs straight into the poem).
+        poem_divider = "<hr style='border:0;border-top:1px solid #e5e7eb;margin:22px 0' />"
+
+    name = (group_name or "").strip()
+    scope = "" if (implicit or not name or name == "All repositories") else f"<div class='subtitle'>{_esc(name)}</div>"
+    period = ""
+    if date_range and date_range.get("start_date_formatted"):
+        period = (f"<div class='subtitle'>Report period: {_esc(date_range.get('start_date_formatted'))} - "
+                  f"{_esc(date_range.get('end_date_formatted'))}</div>")
+
+    return f"""<html><head><meta charset="utf-8" /><style>{_STYLE}</style></head><body>
+<div class="container">
+  <div class="header"><h1>Knowledge Digest</h1>{scope}{period}</div>
+  <table class="stats-bar" role="presentation" cellpadding="0" cellspacing="0" width="100%"><tr>
+    <td><div class="stat-value">{stats.get('commits', 0)}</div><div class="stat-label">Commits</div></td>
+    <td><div class="stat-value">{stats.get('contributors', 0)}</div><div class="stat-label">Contributors</div></td>
+    <td><div class="stat-value">{stats.get('total_repos', 0)}</div><div class="stat-label">Total Repos</div></td>
+    <td><div class="stat-value">{stats.get('active_repos', 0)}</div><div class="stat-label">Active Repos</div></td>
+  </tr></table>
+  <div class="content">
+    <h2>SUMMARY</h2><div class="summary-box"><p>{_esc(summary)}</p></div>
+    <h2>🚀 PRIMARY UPDATES</h2>{_ul(features)}
+    <h2>🛠️ REPOSITORY DEEP DIVE</h2>{repo_html}
+    {rollup_html}
+    {poem_divider}
+    {poem_html}
+  </div>
+  <div class="footer">
+    <p>Generated by <a href="https://gitzoid.com" style="color:#1ED66C;text-decoration:none;">GitZoid</a>
+       · Powered by <a href="https://waveassist.io" style="color:#1ED66C;text-decoration:none;">WaveAssist</a></p>
+    <p class="muted">A PDF version is attached for easy sharing and printing.</p>
+  </div>
+</div></body></html>"""
+
+
+def generate_pdf(html_content, group_name):
+    """Render the email HTML to a PDF BytesIO. Soft-fails to (None, error) if WeasyPrint is unavailable
+    or rendering fails — the email still goes, just without the attachment."""
+    name = pdf_filename(group_name)
+    try:
+        from weasyprint import HTML   # lazy: keep the module importable without WeasyPrint
+        pdf = io.BytesIO(HTML(string=html_content).write_pdf())
+        setattr(pdf, "name", name)
+        pdf.seek(0)
+        return pdf, name, None
+    except Exception as e:
+        return None, name, f"PDF generation failed: {e}"
+
+
+def release_run_lock():
+    """Release the digest lock only if THIS run owns it (token match)."""
+    my_token = waveassist.fetch_data("digest_run_lock_token", run_based=True, default="") or ""
+    if not my_token:
+        return
+    lock = waveassist.fetch_data(RUN_LOCK_KEY, default={}) or {}
+    if isinstance(lock, dict) and lock.get("token") == my_token:
+        waveassist.store_data(RUN_LOCK_KEY, {}, data_type="json")
+        print("GitZoid Digest: released run lock.")
+
+
+# ---------------------------------------------------------------- driver (flat, fall-through)
+
+skip = waveassist.fetch_data("digest_skip_run", run_based=True, default="0") == "1"
+
+if not skip:
+    groups = waveassist.fetch_data("digest_resolved_groups", run_based=True, default=[]) or []
+    business_reports = waveassist.fetch_data("digest_business_reports", run_based=True, default={}) or {}
+    technical_reports = waveassist.fetch_data("digest_technical_reports", run_based=True, default={}) or {}
+    activity = waveassist.fetch_data("github_activity_data", default={}) or {}
+    date_range = waveassist.fetch_data("report_date_range", default={}) or {}
+    digest_state = waveassist.fetch_data("digest_state", default={}) or {}
+    now_iso = datetime.now(timezone.utc).isoformat()
+
+    sent, results = 0, []
+    last_html = ""
+    for group in groups:
+        slug = group.get("slug")
+        name = group.get("name") or "your repositories"
+        business_report = business_reports.get(slug) or {}
+        technical_report = technical_reports.get(slug) or {}
+
+        if group_generation_failed(business_report, technical_report):
+            # An LLM call raised; do NOT send a broken/empty email. Skip and log; last_sent_at untouched.
+            print(f"⚠️ {slug}: report generation failed upstream; skipping send (no broken email)")
+            results.append({"group": name, "sent": False, "skipped": True,
+                            "reason": "generation_failed", "pdf": None, "pdf_error": None})
+            continue
+
+        stats = compute_stats(activity, group.get("repos") or [])
+        html = build_email_html(name, business_report, technical_report, stats, date_range,
+                                implicit=group.get("implicit"))
+        last_html = html
+        pdf_file, pdf_name, pdf_error = generate_pdf(html, name)
+        cc = clean_recipients(group.get("recipients"))
+        try:
+            ok = waveassist.send_email(subject=build_subject(name, date_range.get("end_date_formatted", ""),
+                                                             implicit=group.get("implicit")),
+                                       html_content=html, attachment_file=pdf_file,
+                                       cc=cc or None, raise_on_failure=False)
+        except Exception as e:
+            print(f"⚠️ digest email failed for {slug}: {e}")
+            ok = False
+        if ok:
+            sent += 1
+            # Only stamp last_sent_at on a REAL delivery (mirrors the generation-failed skip path);
+            # a failed send must not look delivered.
+            state = digest_state.get(slug) or {}
+            state["last_sent_at"] = now_iso
+            digest_state[slug] = state
+        results.append({"group": name, "sent": bool(ok), "pdf": pdf_name, "pdf_error": pdf_error})
+        print(f"{'✓' if ok else '⚠️'} {slug}: digest {'sent' if ok else 'send failed'}")
+
+    waveassist.store_data("digest_state", digest_state, data_type="json")
+    attempted = len([r for r in results if not r.get("skipped")])
+    waveassist.store_data("display_output", {
+        "title": f"GitZoid Digest: {sent} email(s) sent",
+        "html_content": last_html or "<p>No groups to send.</p>",
+        "attempted": attempted,
+        "status": digest_status(sent, attempted),
+        "groups": results,
+    }, run_based=True, data_type="json")
+    print(f"GitZoid Digest: sent {sent}/{len(results)} group digest(s).")
+else:
+    print("GitZoid Digest: digest_skip_run set; send_digest no-op.")
+
+release_run_lock()

--- a/tests/e2e/run_digest_e2e.py
+++ b/tests/e2e/run_digest_e2e.py
@@ -1,0 +1,204 @@
+"""
+Manual end-to-end runner for the GitZoid KNOWLEDGE DIGEST pipeline
+(fetch_activity -> analyze_activity -> generate_business_report -> generate_technical_report ->
+send_digest).
+
+Uses LOCAL CLAUDE (never OpenRouter) and an IN-MEMORY store overlay so NOTHING is written to the
+WaveAssist project (no clobbering of any project data). It reads real config (token, selected repos,
+any existing brain, the security_findings ledger) from the project.
+
+The digest only READS GitHub (branches via GraphQL, commits, PRs, diffs) and sends ONE email per
+group to the account owner. It never posts to GitHub. As a safety net for the prod IshaFoundation
+repos, this harness HARD-BLOCKS any GitHub write at the HTTP layer, allowing only the read-only
+GraphQL POST that active-branch detection needs.
+
+It also bypasses the gate node (digest_check_and_init) so the test never touches prod credits or the
+digest_run_lock; it seeds the gate's outputs (digest_skip_run + digest_resolved_groups) directly,
+reproducing the implicit single-group fallback the gate would apply when no digest_groups are set.
+
+Email: preview-only by default (prints + saves the email that WOULD be sent). Pass --send to ACTUALLY
+send it to the project owner via the real WaveAssist backend.
+
+Usage:
+    uid=<UID> project_key=<PROJECT> \\
+      /path/to/python tests/e2e/run_digest_e2e.py [owner/repo ...] [--send] [--out=PATH]
+"""
+import os
+import re
+import sys
+import json
+import html
+import time
+import subprocess
+
+os.environ["LLM_PROVIDER"] = "claude_cli"
+os.environ.setdefault("CLAUDE_CLI_MODEL", "claude-sonnet-4-6")
+UID = os.environ.get("uid")
+PROJECT = os.environ.get("project_key")
+if not UID or not PROJECT:
+    sys.exit("ERROR: set uid=<...> and project_key=<...> in the environment.")
+
+SEND = "--send" in sys.argv
+OUT = next((a.split("=", 1)[1] for a in sys.argv if a.startswith("--out=")), "/tmp/gitzoid_digest_preview.html")
+TARGETS = [a for a in sys.argv[1:] if not a.startswith("--")]
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../")))
+
+import waveassist  # noqa: E402
+from waveassist.utils import create_json_prompt as _cjp, parse_json_response as _pjr  # noqa: E402
+waveassist.init(token=UID, project_key=PROJECT)
+
+
+def _local_call_llm(model, prompt, response_model, **k):
+    jp = _cjp(prompt, response_model)
+    m = os.environ.get("CLAUDE_CLI_MODEL", "claude-sonnet-4-6")
+    cmd = ["claude", "-p", jp, "--output-format", "json", "--model", m,
+           "--max-turns", "1", "--tools", "", "--strict-mcp-config"]
+    r = subprocess.run(cmd, capture_output=True, text=True, timeout=900)
+    if r.returncode != 0:
+        raise RuntimeError(f"local claude rc={r.returncode}: {(r.stderr or r.stdout)[:400]}")
+    return _pjr(json.loads(r.stdout).get("result", ""), response_model, model)
+
+
+# ---- hard GitHub-write guard: reads only. Allow the read-only GraphQL POST; block everything else. ----
+import requests  # noqa: E402
+_real = {"post": requests.post, "patch": requests.patch, "put": requests.put, "delete": requests.delete}
+
+
+def _guard(method):
+    real = _real[method]
+    def f(url, *a, **k):
+        u = str(url)
+        if ("github.com" in u) and not u.rstrip("/").endswith("/graphql"):
+            raise AssertionError(f"BLOCKED GitHub write ({method.upper()}) to {u}")
+        return real(url, *a, **k)
+    return f
+
+
+for _m in _real:
+    setattr(requests, _m, _guard(_m))
+
+# ---- in-memory store overlay: writes stay local, reads fall back to the real project. ----
+_store = {}
+_real_fetch = waveassist.fetch_data
+
+
+def _skey(key, run_based):
+    return (key, bool(run_based))
+
+
+def _fetch(key=None, run_based=False, default=None, **k):
+    sk = _skey(key, run_based)
+    if sk in _store:
+        return _store[sk]
+    return _real_fetch(key, run_based=run_based, default=default)
+
+
+def _store_data(key, value, run_based=False, data_type=None, **k):
+    if data_type == "json" and not isinstance(value, (dict, list)):
+        value = {"value": str(value)}
+    _store[_skey(key, run_based)] = value
+    return True
+
+
+# ---- email capture: preview unless --send ----
+_sent = []
+_real_send = waveassist.send_email
+
+
+def _send_email(**k):
+    _sent.append(k)
+    if SEND:
+        # The local pip SDK (0.8.0) lacks cc/attachment kwargs that PROD's send_email supports (proven
+        # by the cc'd security emails in prod). Pass only what the local signature accepts so the test
+        # still delivers; cc is None for the implicit single group anyway.
+        import inspect
+        allowed = set(inspect.signature(_real_send).parameters)
+        return _real_send(**{kk: vv for kk, vv in k.items() if kk in allowed})
+    return True
+
+
+def _rid(r):
+    return r.get("id") if isinstance(r, dict) else r
+
+
+full = _real_fetch("github_selected_resources", default=[]) or []
+targets = [t for t in (TARGETS or [_rid(r) for r in full]) if t]
+if not targets:
+    sys.exit("ERROR: no repos selected in the project and none passed as args.")
+
+# Reproduce the gate's implicit single-group fallback (no digest_groups configured for this project).
+groups = [{"name": "All repositories", "repos": targets, "recipients": [], "slug": "all-repositories"}]
+_store_data("digest_skip_run", "0", run_based=True, data_type="string")
+_store_data("digest_resolved_groups", groups, run_based=True, data_type="json")
+
+waveassist.init = lambda *a, **k: None           # modules re-call init(); keep our setup
+waveassist.call_llm = _local_call_llm
+waveassist.fetch_data = _fetch
+waveassist.store_data = _store_data
+waveassist.send_email = _send_email
+
+print(f"[digest-e2e] project={PROJECT} model={os.environ['CLAUDE_CLI_MODEL']} "
+      f"email={'SEND (real)' if SEND else 'preview-only'}")
+print(f"[digest-e2e] repos: {', '.join(targets)}")
+print(f"[digest-e2e] GitHub writes HARD-BLOCKED (GraphQL read allowed); nothing written to project.\n")
+
+t0 = time.monotonic()
+
+
+def _stage(label, module):
+    start = time.monotonic()
+    __import__(module)
+    dt = time.monotonic() - start
+    print(f"      ⏱  {label}: {dt:.1f}s")
+    return dt
+
+
+timings = {}
+print("[1/5] fetch_activity (GraphQL branches + commits + PRs) ...")
+timings["fetch_activity"] = _stage("fetch_activity", "fetch_activity")
+activity = _fetch("github_activity_data", default={}) or {}
+dr = _fetch("report_date_range", default={}) or {}
+print(f"      window: {dr.get('start_date_formatted')} → {dr.get('end_date_formatted')}")
+for r, d in activity.items():
+    print(f"      {r}: {len(d.get('commits', []))} commit(s), {len(d.get('pull_requests', []))} PR(s)")
+
+print("\n[2/5] analyze_activity (diffs → structured changes; three-tier splitting) ...")
+timings["analyze_activity"] = _stage("analyze_activity", "analyze_activity")
+analyses = _fetch("repository_analyses", default=[]) or []
+for a in analyses:
+    print(f"      {a.get('repository')}: {len(a.get('changes', []))} change(s)")
+
+print("\n[3/5] generate_business_report (per group) ...")
+timings["generate_business_report"] = _stage("generate_business_report", "generate_business_report")
+
+print("\n[4/5] generate_technical_report (per group + security roll-up) ...")
+timings["generate_technical_report"] = _stage("generate_technical_report", "generate_technical_report")
+tech = _fetch("digest_technical_reports", run_based=True, default={}) or {}
+for slug, rep in tech.items():
+    c = (rep.get("security_rollup") or {}).get("counts", {})
+    print(f"      {slug}: {len(rep.get('repository_deep_dive', []))} repo section(s) | "
+          f"security: {c.get('new', 0)} new / {c.get('still_open', 0)} open / {c.get('resolved', 0)} resolved")
+
+print("\n[5/5] send_digest (render + email) ...")
+timings["send_digest"] = _stage("send_digest", "send_digest")
+
+total = time.monotonic() - t0
+print("\n[digest-e2e] ===== TIMING =====")
+for k, v in timings.items():
+    print(f"   {k:28} {v:6.1f}s")
+print(f"   {'TOTAL':28} {total:6.1f}s")
+
+print(f"\n[digest-e2e] email(s) {'SENT to owner' if SEND else 'PREVIEW (not sent)'}: {len(_sent)}")
+for e in _sent:
+    print(f"   subject: {e.get('subject')} | cc: {e.get('cc')} | "
+          f"pdf: {'yes' if e.get('attachment_file') else 'no (weasyprint absent locally)'}")
+    body = e.get("html_content", "")
+    with open(OUT, "w") as f:
+        f.write(body)
+    text = html.unescape(re.sub(r"<[^>]+>", " ", body))
+    text = re.sub(r"\n\s*\n+", "\n", re.sub(r"[ \t]+", " ", text)).strip()
+    print("\n----- rendered digest (text) -----\n")
+    print(text)
+    print(f"\n----- full HTML saved to: {OUT} -----")
+
+print("\n[digest-e2e] done; nothing written to the project; no GitHub writes.")

--- a/tests/integration/test_digest_workflow.py
+++ b/tests/integration/test_digest_workflow.py
@@ -1,0 +1,90 @@
+"""
+Integration test for the Knowledge Digest chain — runs all six nodes in order against one shared
+in-memory store, verifying the data contracts connect end to end (digest_resolved_groups → activity →
+analyses → per-group reports → email) and that the security_findings ledger flows into the delivered
+email's roll-up. Exercises the quiet-week path (no commits): no LLM is called, yet a digest still ships
+with the security reassurance, and the lock is released.
+"""
+import sys
+import os
+import time
+from datetime import datetime, timezone, timedelta
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../')))
+
+NODES = ["digest_check_and_init", "fetch_activity", "analyze_activity",
+         "generate_business_report", "generate_technical_report", "send_digest"]
+
+
+class Store:
+    """Dict-backed waveassist data store with a separate run-based namespace."""
+    def __init__(self):
+        self.g, self.r = {}, {}
+
+    def fetch(self, key=None, default=None, run_based=False, **k):
+        return (self.r if run_based else self.g).get(key, default)
+
+    def store(self, key, value, run_based=False, data_type=None, **k):
+        (self.r if run_based else self.g)[key] = value
+
+
+class FakeResp:
+    def __init__(self, payload, status=200):
+        self._p, self.status_code, self.links = payload, status, {}
+
+    def json(self):
+        return self._p
+
+
+def test_full_digest_chain_quiet_week_ships_security_rollup(monkeypatch):
+    import runpy, waveassist, requests
+
+    store = Store()
+    # seed: digest on, one repo, and a live security finding for it (new this week)
+    store.g["enable_digest"] = "true"
+    store.g["github_selected_resources"] = [{"id": "o/a"}]
+    store.g["github_access_token"] = "tok"
+    store.g["model_name"] = "anthropic/claude-sonnet-4.6"
+    store.g["security_findings"] = {
+        "sig1": {"repo": "o/a", "status": "open", "severity": "critical", "title": "Auth bypass",
+                 "actively_exploited": True,
+                 "first_seen": (datetime.now(timezone.utc) - timedelta(days=1)).isoformat()},
+    }
+
+    emails = []
+    monkeypatch.setattr(waveassist, "init", lambda *a, **k: None)
+    monkeypatch.setattr(waveassist, "fetch_data", store.fetch)
+    monkeypatch.setattr(waveassist, "store_data", store.store)
+    monkeypatch.setattr(waveassist, "check_credits_and_notify", lambda *a, **k: True)
+    monkeypatch.setattr(waveassist, "send_email", lambda **k: (emails.append(k) or True))
+    # no LLM should be needed on a quiet (no-commit) week
+    monkeypatch.setattr(waveassist, "call_llm",
+                        lambda *a, **k: (_ for _ in ()).throw(AssertionError("no LLM on a quiet week")))
+    # GitHub returns no branches / no commits / no PRs
+    monkeypatch.setattr(requests, "post",
+                        lambda *a, **k: FakeResp({"data": {"repository": {"refs": {"nodes": [],
+                                                  "pageInfo": {"hasNextPage": False}}}}}))
+    monkeypatch.setattr(requests, "get", lambda *a, **k: FakeResp([]))
+    monkeypatch.setattr(time, "sleep", lambda *a, **k: None)
+
+    for node in NODES:
+        runpy.run_path(f"{node}.py", run_name="__main__")
+
+    # contracts connected: gate resolved one implicit group...
+    groups = store.r["digest_resolved_groups"]
+    assert len(groups) == 1 and groups[0]["repos"] == ["o/a"]
+    # ...activity + analyses produced for the repo...
+    assert "o/a" in store.g["github_activity_data"]
+    assert store.g["repository_analyses"][0]["repository"] == "o/a"
+    # ...per-group reports keyed by slug...
+    slug = groups[0]["slug"]
+    assert slug in store.r["digest_business_reports"]
+    assert slug in store.r["digest_technical_reports"]
+    # ...and exactly one digest email shipped, carrying the security roll-up from the ledger.
+    assert len(emails) == 1
+    assert "Auth bypass" in emails[0]["html_content"]
+    assert "actively exploited" in emails[0]["html_content"]
+    # the timer was set, and the lock was acquired then released by send_digest
+    assert store.r["tentative_time_to_process"] is not None
+    assert store.g["digest_run_lock"] == {}
+    assert slug in store.g["digest_state"]

--- a/tests/unit/test_analyze_activity.py
+++ b/tests/unit/test_analyze_activity.py
@@ -1,0 +1,139 @@
+"""
+Unit tests for analyze_activity.py — the Digest chain's diff analyzer (node 3).
+
+The three-tier token-splitting strategy from GitDigest is preserved verbatim; here it is pinned by
+testing batch PLANNING (which commits go in which LLM call, with what budget) separately from LLM
+execution, so the hard-won tiering logic is verified without mocking the model.
+"""
+import sys
+import os
+from datetime import datetime, timezone
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../')))
+
+from analyze_activity import (
+    is_non_code_file,
+    estimate_tokens,
+    group_commits_by_day,
+    choose_tier,
+    batch_small_days,
+    build_commit_context,
+    brain_context_section,
+    TIER_1_THRESHOLD,
+    TIER_2_THRESHOLD,
+    BATCH_THRESHOLD,
+)
+
+
+class TestIsNonCodeFile:
+    def test_image(self):
+        assert is_non_code_file("logo.png") is True
+
+    def test_lockfile(self):
+        assert is_non_code_file("poetry.lock") is True
+
+    def test_code(self):
+        assert is_non_code_file("app.py") is False
+        assert is_non_code_file("Dockerfile") is False
+
+
+class TestEstimateTokens:
+    def test_three_chars_per_token(self):
+        assert estimate_tokens("abcdef") == 2
+        assert estimate_tokens("") == 0
+
+
+class TestChooseTier:
+    def test_tier1_below_100k(self):
+        assert choose_tier(TIER_1_THRESHOLD - 1) == 1
+
+    def test_tier2_between(self):
+        assert choose_tier(TIER_1_THRESHOLD) == 2
+        assert choose_tier(TIER_2_THRESHOLD - 1) == 2
+
+    def test_tier3_above_700k(self):
+        assert choose_tier(TIER_2_THRESHOLD) == 3
+
+
+class TestGroupCommitsByDay:
+    def test_groups_by_calendar_day(self):
+        commits = [
+            {"sha": "a", "timestamp": "2024-01-15T10:00:00Z"},
+            {"sha": "b", "timestamp": "2024-01-15T22:00:00Z"},
+            {"sha": "c", "timestamp": "2024-01-16T01:00:00Z"},
+        ]
+        by_day = group_commits_by_day(commits)
+        assert set(by_day.keys()) == {"2024-01-15", "2024-01-16"}
+        assert [c["sha"] for c in by_day["2024-01-15"]] == ["a", "b"]
+
+    def test_missing_timestamp_bucketed_unknown(self):
+        by_day = group_commits_by_day([{"sha": "x", "timestamp": ""}])
+        assert "unknown" in by_day
+
+
+class TestBatchSmallDays:
+    def test_combines_until_threshold(self):
+        # three days, each 40k tokens; threshold 90k → days 1+2 batch, day 3 alone
+        day_data = [
+            ("2024-01-01", [{"sha": "a"}], 40000),
+            ("2024-01-02", [{"sha": "b"}], 40000),
+            ("2024-01-03", [{"sha": "c"}], 40000),
+        ]
+        batches = batch_small_days(day_data, batch_threshold=90000)
+        assert len(batches) == 2
+        assert [c["sha"] for c in batches[0]["commits"]] == ["a", "b"]
+        assert [c["sha"] for c in batches[1]["commits"]] == ["c"]
+        assert all(b["token_budget"] is None for b in batches)
+
+    def test_empty(self):
+        assert batch_small_days([]) == []
+
+
+class TestBuildCommitContext:
+    def _commit(self, sha="abc1234"):
+        return {"sha": sha, "message": "Add caching", "author": "alice",
+                "timestamp": "2024-01-15T10:00:00Z"}
+
+    def test_includes_commit_and_diff(self):
+        diffs = {"abc1234": [{"filename": "cache.py", "status": "added", "patch": "+ cache code"}]}
+        ctx = build_commit_context([self._commit()], diffs)
+        assert "abc1234" in ctx
+        assert "Add caching" in ctx
+        assert "cache.py" in ctx
+        assert "+ cache code" in ctx
+
+    def test_token_budget_truncates_large_file(self):
+        big_patch = "x" * 60000   # ~20k tokens
+        diffs = {"abc1234": [{"filename": "big.py", "status": "modified", "patch": big_patch}]}
+        ctx = build_commit_context([self._commit()], diffs, token_budget=100)
+        assert "TRUNCATED" in ctx
+
+
+class TestBrainContextSection:
+    def test_empty_profile_no_section(self):
+        assert brain_context_section({}) == ""
+        assert brain_context_section(None) == ""
+
+    def test_architecture_included(self):
+        section = brain_context_section({"architecture_summary": "A FastAPI service"})
+        assert "FastAPI service" in section
+
+    def test_conventions_included(self):
+        section = brain_context_section({"conventions": ["use type hints", "pytest"]})
+        assert "type hints" in section
+
+
+class TestDriverSkip:
+    def test_skip_run_does_no_work(self, monkeypatch):
+        import runpy, waveassist
+        monkeypatch.setattr(waveassist, "init", lambda *a, **k: None)
+        fetch_map = {"digest_skip_run": "1"}
+        stored = {}
+        monkeypatch.setattr(waveassist, "fetch_data",
+                            lambda key=None, default=None, **k: fetch_map.get(key, default))
+        monkeypatch.setattr(waveassist, "store_data",
+                            lambda key, value, **k: stored.__setitem__(key, value))
+        monkeypatch.setattr(waveassist, "call_llm",
+                            lambda *a, **k: (_ for _ in ()).throw(AssertionError("no LLM on skip")))
+        runpy.run_path("analyze_activity.py", run_name="__main__")
+        assert "repository_analyses" not in stored

--- a/tests/unit/test_digest_check_and_init.py
+++ b/tests/unit/test_digest_check_and_init.py
@@ -1,0 +1,209 @@
+"""
+Unit tests for digest_check_and_init.py — the Knowledge Digest chain's weekly starting node.
+
+Mirrors test_security_check_and_init.py. The digest gate differs from security in two ways that
+these tests pin down: the toggle defaults OFF when unset (existing users get no surprise weekly
+email), and the node resolves the per-group working set (with an implicit single-group fallback)
+before any downstream node runs.
+"""
+import sys
+import os
+from datetime import datetime, timezone, timedelta
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../')))
+
+from digest_check_and_init import (
+    lock_is_active,
+    digest_enabled,
+    parse_groups,
+    slugify,
+    resolve_groups,
+    estimate_time_to_process,
+    LOCK_TTL_SECONDS,
+    DIGEST_SECONDS_PER_REPO,
+    DIGEST_BASE_SECONDS,
+)
+
+
+class TestLockActive:
+    def test_empty_lock_inactive(self):
+        assert lock_is_active({}) is False
+        assert lock_is_active(None) is False
+
+    def test_fresh_lock_active(self):
+        assert lock_is_active({"at": datetime.now(timezone.utc).isoformat(), "token": "t"}) is True
+
+    def test_stale_lock_inactive(self):
+        old = (datetime.now(timezone.utc) - timedelta(seconds=LOCK_TTL_SECONDS + 60)).isoformat()
+        assert lock_is_active({"at": old, "token": "t"}) is False
+
+
+class TestDigestEnabled:
+    """OPPOSITE default to security: unset means OFF (existing users), explicit truthy means ON (new)."""
+
+    def test_unset_is_off(self):
+        # Existing users never stored this → must be OFF so they get no surprise weekly email.
+        assert digest_enabled(None) is False
+        assert digest_enabled("") is False
+
+    def test_explicit_true_is_on(self):
+        assert digest_enabled("true") is True
+        assert digest_enabled(True) is True
+        assert digest_enabled("on") is True
+        assert digest_enabled("1") is True
+
+    def test_explicit_false_is_off(self):
+        assert digest_enabled("false") is False
+        assert digest_enabled("off") is False
+        assert digest_enabled(False) is False
+
+
+class TestParseGroups:
+    def test_list_passthrough(self):
+        g = [{"name": "A", "repos": ["o/r"], "recipients": []}]
+        assert parse_groups(g) == g
+
+    def test_json_string_parsed(self):
+        assert parse_groups('[{"name":"A","repos":["o/r"],"recipients":[]}]') == \
+            [{"name": "A", "repos": ["o/r"], "recipients": []}]
+
+    def test_garbage_and_empty_become_empty_list(self):
+        assert parse_groups("not json") == []
+        assert parse_groups("") == []
+        assert parse_groups(None) == []
+        assert parse_groups('{"not":"a list"}') == []
+
+
+class TestSlugify:
+    def test_kebab_case(self):
+        assert slugify("Acme Platform", 0) == "acme-platform"
+
+    def test_strips_punctuation(self):
+        assert slugify("  Mobile / Web!! ", 0) == "mobile-web"
+
+    def test_empty_name_falls_back_to_index(self):
+        assert slugify("", 3) == "group-4"
+        assert slugify(None, 0) == "group-1"
+
+
+class TestResolveGroups:
+    REPOS = [{"id": "o/a"}, {"id": "o/b"}, {"id": "o/c"}]
+
+    def test_explicit_groups_kept_and_intersected_with_selected(self):
+        groups = [{"name": "Front", "repos": ["o/a", "o/x"], "recipients": ["a@x.com"]}]
+        out = resolve_groups(groups, self.REPOS)
+        assert len(out) == 1
+        assert out[0]["repos"] == ["o/a"]          # o/x dropped (not selected)
+        assert out[0]["recipients"] == ["a@x.com"]
+        assert out[0]["slug"] == "front"
+
+    def test_group_with_no_selected_repos_is_dropped(self):
+        groups = [{"name": "Dead", "repos": ["o/gone"], "recipients": []}]
+        out = resolve_groups(groups, self.REPOS)
+        # no surviving explicit group → implicit fallback over all selected repos
+        assert len(out) == 1
+        # The bare "All repositories" label is suppressed; the implicit group is unnamed + flagged.
+        assert out[0]["name"] == ""
+        assert out[0]["implicit"] is True
+        assert sorted(out[0]["repos"]) == ["o/a", "o/b", "o/c"]
+        assert out[0]["recipients"] == []
+
+    def test_implicit_fallback_marked_and_unnamed(self):
+        out = resolve_groups([], self.REPOS)
+        assert out[0]["implicit"] is True
+        assert out[0]["name"] == ""
+        assert out[0]["slug"] == "group-1"
+        assert sorted(out[0]["repos"]) == ["o/a", "o/b", "o/c"]
+
+    def test_explicit_group_not_implicit(self):
+        out = resolve_groups([{"name": "Front", "repos": ["o/a"], "recipients": []}], self.REPOS)
+        assert out[0]["implicit"] is False
+        assert out[0]["slug"] == "front"
+
+    def test_empty_groups_fall_back_to_one_implicit_group(self):
+        out = resolve_groups([], self.REPOS)
+        assert len(out) == 1
+        assert sorted(out[0]["repos"]) == ["o/a", "o/b", "o/c"]
+
+    def test_no_repos_at_all_yields_no_groups(self):
+        assert resolve_groups([], []) == []
+
+    def test_duplicate_names_get_unique_slugs(self):
+        groups = [
+            {"name": "Team", "repos": ["o/a"], "recipients": []},
+            {"name": "Team", "repos": ["o/b"], "recipients": []},
+        ]
+        out = resolve_groups(groups, self.REPOS)
+        slugs = [g["slug"] for g in out]
+        assert slugs == ["team", "team-2"]
+
+    def test_string_repo_list_supported(self):
+        out = resolve_groups([], ["o/a", "o/b"])
+        assert sorted(out[0]["repos"]) == ["o/a", "o/b"]
+
+
+class TestEstimateTimeToProcess:
+    def test_zero_repos_is_just_base(self):
+        assert estimate_time_to_process(0) == DIGEST_BASE_SECONDS
+
+    def test_scales_per_repo(self):
+        assert estimate_time_to_process(4) == 4 * DIGEST_SECONDS_PER_REPO + DIGEST_BASE_SECONDS
+
+    def test_bad_input_falls_back_to_base(self):
+        assert estimate_time_to_process(-2) == DIGEST_BASE_SECONDS
+        assert estimate_time_to_process(None) == DIGEST_BASE_SECONDS
+
+
+class TestDriver:
+    """Driver-level: off/empty cycles are clean no-ops; a proceeding run resolves groups, sets the
+    timer, and takes the lock."""
+
+    def _run(self, monkeypatch, fetch_map, credits=True):
+        import runpy, waveassist
+        stored = {}
+        monkeypatch.setattr(waveassist, "init", lambda *a, **k: None)
+        monkeypatch.setattr(waveassist, "fetch_data",
+                            lambda key=None, default=None, **k: fetch_map.get(key, default))
+        monkeypatch.setattr(waveassist, "store_data",
+                            lambda key, value, **k: stored.__setitem__(key, value))
+        monkeypatch.setattr(waveassist, "check_credits_and_notify", lambda *a, **k: credits)
+        runpy.run_path("digest_check_and_init.py", run_name="__main__")
+        return stored
+
+    def test_disabled_skips_without_credit_check(self, monkeypatch):
+        import waveassist
+        monkeypatch.setattr(waveassist, "check_credits_and_notify",
+                            lambda *a, **k: (_ for _ in ()).throw(AssertionError("no credit check when off")))
+        # enable_digest unset → off
+        stored = self._run(monkeypatch, {"github_selected_resources": [{"id": "o/a"}]})
+        assert stored.get("digest_skip_run") == "1"
+        assert "digest_run_lock" not in stored
+
+    def test_no_repos_skips(self, monkeypatch):
+        stored = self._run(monkeypatch, {"enable_digest": "true", "github_selected_resources": []})
+        assert stored.get("digest_skip_run") == "1"
+
+    def test_active_lock_skips_cycle(self, monkeypatch):
+        fresh = {"at": datetime.now(timezone.utc).isoformat(), "token": "other"}
+        stored = self._run(monkeypatch, {"enable_digest": "true",
+                                         "github_selected_resources": [{"id": "o/a"}],
+                                         "digest_run_lock": fresh})
+        assert stored.get("digest_skip_run") == "1"
+        assert "digest_run_lock_token" not in stored
+
+    def test_proceeding_run_resolves_groups_sets_timer_and_lock(self, monkeypatch):
+        repos = [{"id": "o/a"}, {"id": "o/b"}]
+        stored = self._run(monkeypatch, {"enable_digest": "true",
+                                         "github_selected_resources": repos})
+        assert stored.get("digest_skip_run") == "0"
+        groups = stored.get("digest_resolved_groups")
+        assert isinstance(groups, list) and len(groups) == 1          # implicit single group
+        assert sorted(groups[0]["repos"]) == ["o/a", "o/b"]
+        assert stored.get("tentative_time_to_process") == str(estimate_time_to_process(2))
+        assert "digest_run_lock_token" in stored
+
+    def test_no_credits_raises(self, monkeypatch):
+        import pytest
+        with pytest.raises(Exception):
+            self._run(monkeypatch, {"enable_digest": "true",
+                                    "github_selected_resources": [{"id": "o/a"}]}, credits=False)

--- a/tests/unit/test_fetch_activity.py
+++ b/tests/unit/test_fetch_activity.py
@@ -1,0 +1,168 @@
+"""
+Unit tests for fetch_activity.py — the Digest chain's GitHub activity collector (node 2).
+
+Adapted from GitDigest's fetch_github_activity: same 7-day window, GraphQL active-branch detection,
+bot filter, and SHA dedupe. The pure parsing/filter helpers are pinned here; the HTTP pagination
+loops are thin glue over them.
+"""
+import sys
+import os
+from datetime import datetime, timezone, timedelta
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../')))
+
+from fetch_activity import (
+    is_bot_user,
+    parse_commit,
+    pr_in_window,
+    parse_pr,
+    filter_active_branches,
+    build_date_range,
+    repos_to_scan,
+    dedupe_commits,
+    DAYS_TO_FETCH,
+)
+
+
+class TestIsBotUser:
+    def test_type_bot(self):
+        assert is_bot_user({"type": "Bot"}) is True
+
+    def test_bot_suffix_login(self):
+        assert is_bot_user({"login": "some-app[bot]"}) is True
+
+    def test_known_bot(self):
+        assert is_bot_user({"login": "dependabot"}) is True
+        assert is_bot_user({"login": "renovate"}) is True
+
+    def test_human(self):
+        assert is_bot_user({"login": "alice", "type": "User"}) is False
+
+    def test_none(self):
+        assert is_bot_user(None) is False
+        assert is_bot_user({}) is False
+
+
+class TestParseCommit:
+    def _commit(self, sha="abc", login="alice", bot_type="User"):
+        return {
+            "sha": sha,
+            "html_url": f"https://github.com/o/r/commit/{sha}",
+            "author": {"login": login, "type": bot_type},
+            "committer": {"login": login, "type": bot_type},
+            "commit": {"message": "Fix bug", "author": {"name": login, "date": "2024-01-15T10:30:00Z"}},
+        }
+
+    def test_valid_commit(self):
+        c = parse_commit(self._commit())
+        assert c == {"sha": "abc", "message": "Fix bug", "author": "alice",
+                     "timestamp": "2024-01-15T10:30:00Z",
+                     "url": "https://github.com/o/r/commit/abc"}
+
+    def test_bot_commit_dropped(self):
+        assert parse_commit(self._commit(login="dependabot", bot_type="Bot")) is None
+
+    def test_empty_sha_dropped(self):
+        assert parse_commit(self._commit(sha="")) is None
+
+
+class TestPrInWindow:
+    def setup_method(self):
+        self.now = datetime(2024, 1, 15, tzinfo=timezone.utc)
+        self.since = self.now - timedelta(days=7)
+
+    def _pr(self, created=None, merged=None, updated=None):
+        return {"created_at": created or "", "merged_at": merged, "updated_at": updated or ""}
+
+    def test_created_in_window(self):
+        assert pr_in_window(self._pr(created="2024-01-14T00:00:00Z"), self.since) is True
+
+    def test_merged_in_window_created_old(self):
+        pr = self._pr(created="2023-12-01T00:00:00Z", merged="2024-01-13T00:00:00Z")
+        assert pr_in_window(pr, self.since) is True
+
+    def test_updated_in_window_only(self):
+        pr = self._pr(created="2023-12-01T00:00:00Z", updated="2024-01-12T00:00:00Z")
+        assert pr_in_window(pr, self.since) is True
+
+    def test_all_old(self):
+        pr = self._pr(created="2023-11-01T00:00:00Z", merged="2023-11-02T00:00:00Z",
+                      updated="2023-11-03T00:00:00Z")
+        assert pr_in_window(pr, self.since) is False
+
+
+class TestParsePr:
+    def test_shapes_fields(self):
+        pr = {"number": 42, "title": "Add feature", "body": "desc",
+              "user": {"login": "alice"}, "created_at": "2024-01-15T11:00:00Z",
+              "merged_at": None, "updated_at": "2024-01-15T11:00:00Z",
+              "html_url": "https://github.com/o/r/pull/42",
+              "head": {"sha": "def"}, "base": {"ref": "main"}}
+        out = parse_pr(pr, "open")
+        assert out["number"] == 42
+        assert out["status"] == "open"
+        assert out["author"] == "alice"
+        assert out["base_branch"] == "main"
+        assert out["head_sha"] == "def"
+
+
+class TestFilterActiveBranches:
+    def setup_method(self):
+        self.since = datetime(2024, 1, 8, tzinfo=timezone.utc)
+
+    def test_recent_branch_included(self):
+        branches = [{"name": "main", "committedDate": "2024-01-15T10:00:00Z"}]
+        assert filter_active_branches(branches, self.since) == ["main"]
+
+    def test_old_branch_excluded(self):
+        branches = [{"name": "stale", "committedDate": "2023-12-01T10:00:00Z"}]
+        assert filter_active_branches(branches, self.since) == []
+
+    def test_malformed_date_excluded(self):
+        branches = [{"name": "weird", "committedDate": "not-a-date"}]
+        assert filter_active_branches(branches, self.since) == []
+
+
+class TestDedupeCommits:
+    def test_drops_repeated_shas_keeps_order(self):
+        commits = [{"sha": "a"}, {"sha": "b"}, {"sha": "a"}, {"sha": "c"}]
+        assert [c["sha"] for c in dedupe_commits(commits)] == ["a", "b", "c"]
+
+
+class TestBuildDateRange:
+    def test_formats(self):
+        start = datetime(2024, 1, 8, tzinfo=timezone.utc)
+        end = datetime(2024, 1, 15, tzinfo=timezone.utc)
+        out = build_date_range(start, end)
+        assert out["start_date"] == start.isoformat()
+        assert out["end_date"] == end.isoformat()
+        assert out["start_date_formatted"] == "January 08, 2024"
+        assert out["end_date_formatted"] == "January 15, 2024"
+
+
+class TestReposToScan:
+    def test_union_unique_sorted(self):
+        groups = [{"repos": ["o/b", "o/a"]}, {"repos": ["o/a", "o/c"]}]
+        assert repos_to_scan(groups) == ["o/a", "o/b", "o/c"]
+
+    def test_empty(self):
+        assert repos_to_scan([]) == []
+
+
+class TestDriverSkip:
+    def test_skip_run_does_no_work(self, monkeypatch):
+        import runpy, waveassist, requests
+        monkeypatch.setattr(waveassist, "init", lambda *a, **k: None)
+        fetch_map = {"digest_skip_run": "1"}
+        stored = {}
+        monkeypatch.setattr(waveassist, "fetch_data",
+                            lambda key=None, default=None, **k: fetch_map.get(key, default))
+        monkeypatch.setattr(waveassist, "store_data",
+                            lambda key, value, **k: stored.__setitem__(key, value))
+        # Any HTTP call would be a bug when skipping.
+        monkeypatch.setattr(requests, "get",
+                            lambda *a, **k: (_ for _ in ()).throw(AssertionError("no HTTP on skip")))
+        monkeypatch.setattr(requests, "post",
+                            lambda *a, **k: (_ for _ in ()).throw(AssertionError("no HTTP on skip")))
+        runpy.run_path("fetch_activity.py", run_name="__main__")
+        assert "github_activity_data" not in stored

--- a/tests/unit/test_generate_business_report.py
+++ b/tests/unit/test_generate_business_report.py
@@ -1,0 +1,175 @@
+"""
+Unit tests for generate_business_report.py — Digest chain node 4 (per group).
+
+Adapted from GitDigest: same BusinessReport shape and rolling 1-week history, but fanned out per
+resolved group (each group is its own "project") and grounded in the brain instead of the dropped
+repository_contexts.
+"""
+import sys
+import os
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../')))
+
+from generate_business_report import (
+    filter_analyses,
+    count_changes,
+    build_changes_context,
+    build_history_context,
+    roll_history,
+    brain_block,
+)
+
+
+ANALYSES = [
+    {"repository": "o/a", "changes": [{"summary": "Add login", "category": "feature",
+                                       "contributing_commits": ["s1"]}]},
+    {"repository": "o/b", "changes": []},
+    {"repository": "o/c", "changes": [{"summary": "Cache", "category": "improvement",
+                                       "contributing_commits": ["s2"]}]},
+]
+
+
+class TestFilterAnalyses:
+    def test_keeps_only_group_repos(self):
+        out = filter_analyses(ANALYSES, ["o/a", "o/b"])
+        assert {a["repository"] for a in out} == {"o/a", "o/b"}
+
+    def test_empty_group(self):
+        assert filter_analyses(ANALYSES, []) == []
+
+
+class TestCountChanges:
+    def test_sums_changes(self):
+        assert count_changes(ANALYSES) == 2
+
+    def test_zero(self):
+        assert count_changes([{"repository": "o/b", "changes": []}]) == 0
+
+
+class TestBuildChangesContext:
+    def test_only_repos_with_changes(self):
+        ctx = build_changes_context(ANALYSES)
+        assert "o/a" in ctx and "o/c" in ctx
+        assert "o/b" not in ctx          # no changes → excluded
+
+    def test_empty_when_no_changes(self):
+        assert build_changes_context([{"repository": "o/b", "changes": []}]) == ""
+
+
+class TestBuildHistoryContext:
+    def test_empty(self):
+        assert build_history_context([]) == ""
+
+    def test_includes_prior_week(self):
+        hist = [{"week": "2024-01-08", "report": {"executive_summary": "Shipped auth"}}]
+        ctx = build_history_context(hist)
+        assert "2024-01-08" in ctx and "Shipped auth" in ctx
+
+
+class TestRollHistory:
+    def test_keeps_last_one_then_appends(self):
+        hist = [{"week": "2024-01-01", "report": {}}, {"week": "2024-01-08", "report": {}}]
+        out = roll_history(hist, "2024-01-15", {"executive_summary": "new"})
+        assert [h["week"] for h in out] == ["2024-01-08", "2024-01-15"]   # max 2, oldest dropped
+
+    def test_from_empty(self):
+        out = roll_history([], "2024-01-15", {"executive_summary": "first"})
+        assert len(out) == 1 and out[0]["week"] == "2024-01-15"
+
+
+class TestBrainBlock:
+    def test_empty(self):
+        assert brain_block({}) == ""
+
+    def test_includes_arch(self):
+        block = brain_block({"o/a": {"architecture_summary": "FastAPI service"}})
+        assert "FastAPI service" in block
+
+
+class TestDriver:
+    def _run(self, monkeypatch, fetch_map, llm=None):
+        import runpy, waveassist
+        stored = {}
+        monkeypatch.setattr(waveassist, "init", lambda *a, **k: None)
+        monkeypatch.setattr(waveassist, "fetch_data",
+                            lambda key=None, default=None, **k: fetch_map.get(key, default))
+        monkeypatch.setattr(waveassist, "store_data",
+                            lambda key, value, **k: stored.__setitem__(key, value))
+        if llm is not None:
+            monkeypatch.setattr(waveassist, "call_llm", llm)
+        runpy.run_path("generate_business_report.py", run_name="__main__")
+        return stored
+
+    def test_skip_run_no_work(self, monkeypatch):
+        import waveassist
+        stored = self._run(monkeypatch, {"digest_skip_run": "1"},
+                           llm=lambda *a, **k: (_ for _ in ()).throw(AssertionError("no LLM on skip")))
+        assert "digest_business_reports" not in stored
+
+    def test_per_group_report_keyed_by_slug(self, monkeypatch):
+        class FakeReport:
+            def model_dump(self, by_alias=False):
+                return {"executive_summary": "Big week", "shipped_features": ["X"]}
+        groups = [{"name": "Front", "repos": ["o/a"], "recipients": [], "slug": "front"}]
+        stored = self._run(monkeypatch, {
+            "digest_skip_run": "0",
+            "digest_resolved_groups": groups,
+            "repository_analyses": ANALYSES,
+            "digest_state": {},
+        }, llm=lambda *a, **k: FakeReport())
+        reports = stored.get("digest_business_reports")
+        assert "front" in reports
+        assert reports["front"]["executive_summary"] == "Big week"
+
+    def test_group_with_no_activity_gets_fallback_no_llm(self, monkeypatch):
+        groups = [{"name": "Idle", "repos": ["o/b"], "recipients": [], "slug": "idle"}]
+        stored = self._run(monkeypatch, {
+            "digest_skip_run": "0",
+            "digest_resolved_groups": groups,
+            "repository_analyses": ANALYSES,
+            "digest_state": {},
+        }, llm=lambda *a, **k: (_ for _ in ()).throw(AssertionError("no LLM for an idle group")))
+        reports = stored.get("digest_business_reports")
+        assert reports["idle"]["shipped_features"] == []
+
+    def test_quiet_week_not_flagged_failed(self, monkeypatch):
+        """A deterministic quiet week (no changes, no LLM) is NOT a generation failure — it still ships."""
+        groups = [{"name": "Idle", "repos": ["o/b"], "recipients": [], "slug": "idle"}]
+        stored = self._run(monkeypatch, {
+            "digest_skip_run": "0",
+            "digest_resolved_groups": groups,
+            "repository_analyses": ANALYSES,
+            "digest_state": {},
+        }, llm=lambda *a, **k: (_ for _ in ()).throw(AssertionError("no LLM for an idle group")))
+        reports = stored.get("digest_business_reports")
+        assert not reports["idle"].get("generation_failed")
+
+    def test_llm_success_not_flagged(self, monkeypatch):
+        """A successful LLM generation is never flagged as failed."""
+        class FakeReport:
+            def model_dump(self, by_alias=False):
+                return {"executive_summary": "Big week", "shipped_features": ["X"]}
+        groups = [{"name": "Front", "repos": ["o/a"], "recipients": [], "slug": "front"}]
+        stored = self._run(monkeypatch, {
+            "digest_skip_run": "0",
+            "digest_resolved_groups": groups,
+            "repository_analyses": ANALYSES,
+            "digest_state": {},
+        }, llm=lambda *a, **k: FakeReport())
+        reports = stored.get("digest_business_reports")
+        assert not reports["front"].get("generation_failed")
+
+    def test_llm_failure_flags_generation_failed(self, monkeypatch):
+        """When call_llm RAISES, the group is flagged generation_failed and history is NOT advanced."""
+        groups = [{"name": "Front", "repos": ["o/a"], "recipients": [], "slug": "front"}]
+        stored = self._run(monkeypatch, {
+            "digest_skip_run": "0",
+            "digest_resolved_groups": groups,
+            "repository_analyses": ANALYSES,
+            "digest_state": {},
+        }, llm=lambda *a, **k: (_ for _ in ()).throw(RuntimeError("boom")))
+        reports = stored.get("digest_business_reports")
+        assert reports["front"]["generation_failed"] is True
+        assert reports["front"]["shipped_features"] == []        # empty_report shape preserved
+        # history not advanced on failure
+        assert "business_report_history" not in (stored.get("digest_state", {}).get("front", {}) or {})

--- a/tests/unit/test_generate_review.py
+++ b/tests/unit/test_generate_review.py
@@ -20,6 +20,7 @@ from generate_review import (
     finding_sig,
     apply_gate,
     security_sweep,
+    verify_posted_findings,
     _format_brain_profile,
     brain_auth_files,
     brain_secret_locations,
@@ -277,3 +278,34 @@ class TestBrainAdapters:
         assert "repo_profile" in h
         assert _format_brain_profile({}) == ""
         assert _format_brain_profile(None) == ""
+
+
+class TestVerifyFailOpen:
+    """Verification must DROP a finding only on an EXPLICIT refutation (is_real is False). A None or
+    missing is_real (e.g. a null-filled LLM result) must fail OPEN and keep the finding."""
+
+    def _call(self, verdict_dict):
+        pr = {"id": "o/r", "current_sha": "sha",
+              "files": [{"filename": "a.py", "patch": "@@ -1 +1 @@\n+x = 1"}]}
+        diff_lines = build_diff_lines(pr["files"])
+        findings = [{"path": "a.py", "line": 1, "side": "RIGHT", "category": "bug",
+                     "severity": "high", "body": "off-by-one", "confidence": "high"}]
+        vmock = Mock()
+        vmock.model_dump.return_value = verdict_dict
+        with patch("generate_review.fetch_file_text", return_value="x = 1\n"), \
+             patch("generate_review.waveassist") as wa:
+            wa.call_llm.return_value = vmock
+            return verify_posted_findings(findings, pr, "tok", "model", diff_lines, "high")
+
+    def test_keeps_when_is_real_none(self):
+        _, _, dropped = self._call({"is_real": None, "true_severity": "high", "reason": ""})
+        assert dropped == []                       # not actively refuted -> kept (fail open)
+
+    def test_keeps_when_is_real_missing_key(self):
+        _, _, dropped = self._call({"true_severity": "high", "reason": ""})
+        assert dropped == []
+
+    def test_drops_on_explicit_false(self):
+        _, _, dropped = self._call({"is_real": False, "true_severity": "low", "reason": "guarded above"})
+        assert len(dropped) == 1
+        assert dropped[0]["_drop_reason"] == "guarded above"

--- a/tests/unit/test_generate_technical_report.py
+++ b/tests/unit/test_generate_technical_report.py
@@ -1,0 +1,221 @@
+"""
+Unit tests for generate_technical_report.py — Digest chain node 5 (per group).
+
+Adapted from GitDigest's technical report (repository_deep_dive + poem), fanned out per group, plus a
+NEW deterministic security roll-up computed from the security_findings ledger — the weekly
+"we watched, here's the state" reassurance that makes Security Watch's silence trustworthy.
+"""
+import sys
+import os
+from datetime import datetime, timezone, timedelta
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../')))
+
+from generate_technical_report import (
+    filter_analyses,
+    count_changes,
+    build_business_report_context,
+    security_rollup,
+    QUIET_POEM,
+)
+
+NOW = datetime(2024, 1, 15, tzinfo=timezone.utc)
+
+LEDGER = {
+    "s1": {"repo": "o/a", "status": "open", "severity": "critical", "title": "SQL injection",
+           "actively_exploited": False, "first_seen": "2024-01-14T00:00:00+00:00"},     # new (<7d)
+    "s2": {"repo": "o/a", "status": "open", "severity": "medium", "title": "carried over",
+           "actively_exploited": False, "first_seen": "2024-01-01T00:00:00+00:00"},     # still open (>7d)
+    "s3": {"repo": "o/a", "status": "resolved", "severity": "high", "title": "patched dep",
+           "resolved_at": "2024-01-13T00:00:00+00:00"},                                 # resolved (<7d)
+    "s4": {"repo": "o/other", "status": "open", "severity": "high", "title": "other group",
+           "first_seen": "2024-01-14T00:00:00+00:00"},                                  # not in group
+    "s5": {"repo": "o/a", "status": "resolved", "severity": "low", "title": "old resolution",
+           "resolved_at": "2023-12-01T00:00:00+00:00"},                                 # resolved long ago
+}
+
+
+def recent_ledger():
+    """A ledger keyed to the real 'now' the driver uses (datetime.now), so the 7-day window applies."""
+    now = datetime.now(timezone.utc)
+    iso = lambda days: (now - timedelta(days=days)).isoformat()
+    return {
+        "s1": {"repo": "o/a", "status": "open", "severity": "critical", "title": "SQL injection",
+               "actively_exploited": False, "first_seen": iso(1)},          # new
+        "s2": {"repo": "o/a", "status": "open", "severity": "medium", "title": "carried over",
+               "actively_exploited": False, "first_seen": iso(30)},         # still open
+        "s3": {"repo": "o/a", "status": "resolved", "severity": "high", "title": "patched dep",
+               "resolved_at": iso(2)},                                      # resolved this week
+    }
+
+
+class TestSecurityRollup:
+    def test_partitions_new_open_resolved_for_group_only(self):
+        out = security_rollup(LEDGER, ["o/a"], NOW)
+        assert [i["title"] for i in out["new"]] == ["SQL injection"]
+        assert [i["title"] for i in out["still_open"]] == ["carried over"]
+        assert [i["title"] for i in out["resolved"]] == ["patched dep"]
+        assert out["counts"] == {"new": 1, "still_open": 1, "resolved": 1}
+
+    def test_other_group_repo_excluded(self):
+        out = security_rollup(LEDGER, ["o/a"], NOW)
+        titles = {i["title"] for part in ("new", "still_open", "resolved") for i in out[part]}
+        assert "other group" not in titles
+
+    def test_clean_week_all_zero(self):
+        out = security_rollup({}, ["o/a"], NOW)
+        assert out["counts"] == {"new": 0, "still_open": 0, "resolved": 0}
+
+    def test_actively_exploited_sorts_first(self):
+        ledger = {
+            "a": {"repo": "o/a", "status": "open", "severity": "low", "title": "kev low",
+                  "actively_exploited": True, "first_seen": "2024-01-14T00:00:00+00:00"},
+            "b": {"repo": "o/a", "status": "open", "severity": "critical", "title": "crit",
+                  "actively_exploited": False, "first_seen": "2024-01-14T00:00:00+00:00"},
+        }
+        out = security_rollup(ledger, ["o/a"], NOW)
+        assert out["new"][0]["title"] == "kev low"   # KEV outranks even a critical
+
+
+class TestFilterAndCount:
+    ANALYSES = [{"repository": "o/a", "changes": [{"summary": "x", "category": "fix",
+                                                   "contributing_commits": []}]},
+                {"repository": "o/b", "changes": []}]
+
+    def test_filter(self):
+        assert {a["repository"] for a in filter_analyses(self.ANALYSES, ["o/a"])} == {"o/a"}
+
+    def test_count(self):
+        assert count_changes(self.ANALYSES) == 1
+
+
+def test_fallback_poem_constant_removed():
+    """The FALLBACK_POEM constant is removed; a generation failure must NOT render a poem at all."""
+    import generate_technical_report as m
+    assert not hasattr(m, "FALLBACK_POEM")
+
+
+class TestBuildBusinessReportContext:
+    def test_empty(self):
+        assert build_business_report_context({}) == ""
+
+    def test_includes_summary_and_features(self):
+        ctx = build_business_report_context({"executive_summary": "Shipped auth",
+                                             "shipped_features": ["SSO login"]})
+        assert "Shipped auth" in ctx and "SSO login" in ctx
+
+
+class TestDriver:
+    def _run(self, monkeypatch, fetch_map, llm=None):
+        import runpy, waveassist
+        stored = {}
+        monkeypatch.setattr(waveassist, "init", lambda *a, **k: None)
+        monkeypatch.setattr(waveassist, "fetch_data",
+                            lambda key=None, default=None, **k: fetch_map.get(key, default))
+        monkeypatch.setattr(waveassist, "store_data",
+                            lambda key, value, **k: stored.__setitem__(key, value))
+        if llm is not None:
+            monkeypatch.setattr(waveassist, "call_llm", llm)
+        runpy.run_path("generate_technical_report.py", run_name="__main__")
+        return stored
+
+    def test_skip_run_no_work(self, monkeypatch):
+        stored = self._run(monkeypatch, {"digest_skip_run": "1"},
+                           llm=lambda *a, **k: (_ for _ in ()).throw(AssertionError("no LLM on skip")))
+        assert "digest_technical_reports" not in stored
+
+    def test_quiet_group_still_gets_security_rollup_no_llm(self, monkeypatch):
+        groups = [{"name": "Idle", "repos": ["o/a"], "recipients": [], "slug": "idle"}]
+        stored = self._run(monkeypatch, {
+            "digest_skip_run": "0",
+            "digest_resolved_groups": groups,
+            "repository_analyses": [{"repository": "o/a", "changes": []}],
+            "digest_business_reports": {},
+            "security_findings": recent_ledger(),
+        }, llm=lambda *a, **k: (_ for _ in ()).throw(AssertionError("no LLM for a quiet group")))
+        reports = stored.get("digest_technical_reports")
+        assert reports["idle"]["repository_deep_dive"] == []
+        assert "security_rollup" in reports["idle"]            # reassurance present even when quiet
+        assert reports["idle"]["security_rollup"]["counts"]["new"] == 1
+
+    def test_quiet_group_not_flagged_failed(self, monkeypatch):
+        """A quiet week keeps the QUIET poem and is NOT flagged as a generation failure."""
+        groups = [{"name": "Idle", "repos": ["o/a"], "recipients": [], "slug": "idle"}]
+        stored = self._run(monkeypatch, {
+            "digest_skip_run": "0",
+            "digest_resolved_groups": groups,
+            "repository_analyses": [{"repository": "o/a", "changes": []}],
+            "digest_business_reports": {},
+            "security_findings": recent_ledger(),
+        }, llm=lambda *a, **k: (_ for _ in ()).throw(AssertionError("no LLM for a quiet group")))
+        reports = stored.get("digest_technical_reports")
+        assert not reports["idle"].get("generation_failed")
+        assert reports["idle"]["poem"] == QUIET_POEM           # quiet week keeps the QUIET poem
+
+    def test_no_fallback_poem_rendered(self, monkeypatch):
+        """When call_llm RAISES on an active group, flag generation_failed, render NO poem (no fallback),
+        empty deep-dive, but still attach the (correct) security roll-up."""
+        groups = [{"name": "Front", "repos": ["o/a"], "recipients": [], "slug": "front"}]
+        stored = self._run(monkeypatch, {
+            "digest_skip_run": "0",
+            "digest_resolved_groups": groups,
+            "repository_analyses": [{"repository": "o/a", "changes": [{"summary": "x", "category": "feature",
+                                                                       "contributing_commits": []}]}],
+            "digest_business_reports": {"front": {"executive_summary": "s", "shipped_features": []}},
+            "security_findings": recent_ledger(),
+        }, llm=lambda *a, **k: (_ for _ in ()).throw(RuntimeError("boom")))
+        report = stored["digest_technical_reports"]["front"]
+        assert report["generation_failed"] is True
+        assert report["poem"] == []                            # decisive: NO FALLBACK_POEM
+        assert report["repository_deep_dive"] == []
+        assert "security_rollup" in report
+        assert report["security_rollup"]["counts"]["resolved"] == 1
+
+    def test_active_group_runs_llm_and_attaches_rollup(self, monkeypatch):
+        class FakeTech:
+            def model_dump(self, by_alias=False):
+                return {"repository_deep_dive": [{"repo_name": "o/a", "status": "Feature Dev",
+                                                  "technical_changes": ["did x"]}],
+                        "poem": ["a", "b", "c", "d"]}
+        groups = [{"name": "Front", "repos": ["o/a"], "recipients": [], "slug": "front"}]
+        stored = self._run(monkeypatch, {
+            "digest_skip_run": "0",
+            "digest_resolved_groups": groups,
+            "repository_analyses": [{"repository": "o/a", "changes": [{"summary": "x", "category": "feature",
+                                                                       "contributing_commits": []}]}],
+            "digest_business_reports": {"front": {"executive_summary": "s", "shipped_features": []}},
+            "security_findings": recent_ledger(),
+        }, llm=lambda *a, **k: FakeTech())
+        report = stored.get("digest_technical_reports")["front"]
+        assert report["repository_deep_dive"][0]["repo_name"] == "o/a"
+        assert report["security_rollup"]["counts"]["resolved"] == 1
+
+
+class TestRollupGroupsDependencies:
+    """Fix A: the digest security roll-up must group a package's many advisories into ONE issue and
+    label it with a version, matching the alert email — not count 13 CVEs as 13 'django' lines."""
+
+    def test_dep_cves_grouped_into_one_issue(self):
+        now = datetime.now(timezone.utc)
+        iso = now.isoformat()
+        ledger = {f"sig{i}": {"category": "dependency", "repo": "o/a", "name": "Django",
+                              "version": "4.2", "vuln_id": f"GHSA-{i}",
+                              "severity": "critical" if i == 0 else "high",
+                              "status": "open", "first_seen": iso} for i in range(13)}
+        out = security_rollup(ledger, ["o/a"], now)
+        assert out["counts"]["new"] == 1                 # 13 CVEs -> ONE grouped issue
+        item = out["new"][0]
+        assert item["title"] == "Django 4.2"             # version-bearing title (was bare "django")
+        assert item["count"] == 13
+        assert item["severity"] == "critical"            # worst severity in the group
+
+    def test_distinct_packages_stay_separate(self):
+        now = datetime.now(timezone.utc); iso = now.isoformat()
+        ledger = {
+            "a": {"category": "dependency", "repo": "o/a", "name": "Django", "version": "4.2",
+                  "vuln_id": "G1", "severity": "high", "status": "open", "first_seen": iso},
+            "b": {"category": "dependency", "repo": "o/a", "name": "authlib", "version": "1.6",
+                  "vuln_id": "G2", "severity": "high", "status": "open", "first_seen": iso},
+        }
+        out = security_rollup(ledger, ["o/a"], now)
+        assert out["counts"]["new"] == 2

--- a/tests/unit/test_post_comment.py
+++ b/tests/unit/test_post_comment.py
@@ -17,9 +17,12 @@ from post_comment import (
     reconcile_ledger,
     update_reviewed_prs,
     create_pr_review,
+    create_single_review_comment,
     create_summary_comment,
     edit_summary_comment,
     find_summary_comment_id,
+    process_one_pr,
+    run_driver,
     release_run_lock,
     SUMMARY_MARKER,
 )
@@ -292,3 +295,144 @@ class TestReleaseRunLockRunBasedScoping:
         with patch.object(post_comment, "waveassist", wa_a):
             release_run_lock()
         assert store["run_lock"] == {}, "holder failed to release its own lock"
+
+
+# ---------------------------------------------------------------- robustness (issue #6)
+
+class TestFindingsToInlineFalsyPath:
+    """An inline comment with a falsy path makes GitHub 422 the WHOLE batch — drop it instead."""
+
+    def test_falsy_path_dropped(self):
+        assert findings_to_inline_comments([_F(path="")]) == []
+        assert findings_to_inline_comments([_F(path=None)]) == []
+
+    def test_normal_finding_still_emitted(self):
+        assert len(findings_to_inline_comments([_F()])) == 1   # regression guard
+
+
+class TestNoneSafeRendering:
+    """A None/scalar field from the ledger or a null-filled LLM result must never crash the summary."""
+
+    def test_none_body_and_path_do_not_crash(self):
+        ledger = {"s1": {"path": None, "line": None, "body": None, "category": "bug",
+                         "severity": "high", "status": "open"}}
+        md = build_summary_md({"verdict": "minor_comments", "summary": "a single string summary"},
+                              ledger, [], "abc1234")
+        assert isinstance(md, str)
+        assert "None" not in md                              # no literal "None" leaked
+        assert "a single string summary" in md               # string summary -> one bullet, not per-char
+
+    def test_summary_list_with_none_and_scalar(self):
+        md = build_summary_md({"summary": ["ok", None, 5]}, {}, [], "abc1234")
+        assert "- ok" in md
+        assert "- 5" in md                                   # scalar coerced to str
+        assert "None" not in md
+
+
+class TestInline422Fallback:
+    """A single bad line-anchor must not lose the whole inline review — fall back per-comment."""
+
+    @patch('post_comment.requests.post')
+    def test_falls_back_to_per_comment(self, mock_post):
+        def router(url, *a, **k):
+            return _resp(422) if url.endswith("/reviews") else _resp(201, {"id": 1})
+        mock_post.side_effect = router
+        c1 = {"path": "a.py", "line": 5, "side": "RIGHT", "body": "x"}
+        c2 = {"path": "b.py", "line": 9, "side": "RIGHT", "body": "y"}
+        out = create_pr_review("o/r", 1, "sha", "", [c1, c2], "tok")
+        assert out is not None                               # at least one comment posted
+        assert mock_post.call_count == 3                     # 1 batch + 2 per-comment
+
+    @patch('post_comment.requests.post')
+    def test_skips_only_the_bad_comment(self, mock_post):
+        seq = {"n": 0}
+        def router(url, *a, **k):
+            if url.endswith("/reviews"):
+                return _resp(422)
+            seq["n"] += 1
+            return _resp(201, {"id": 1}) if seq["n"] == 1 else _resp(422)
+        mock_post.side_effect = router
+        c1 = {"path": "a.py", "line": 5, "side": "RIGHT", "body": "x"}
+        c2 = {"path": "b.py", "line": 9, "side": "RIGHT", "body": "y"}
+        out = create_pr_review("o/r", 1, "sha", "", [c1, c2], "tok")
+        assert out is not None                               # one still posted, the bad one skipped
+        assert mock_post.call_count == 3
+
+    @patch('post_comment.requests.post')
+    def test_non_422_failure_still_returns_none(self, mock_post):
+        mock_post.return_value = _resp(500)
+        out = create_pr_review("o/r", 1, "sha", "", [{"path": "a.py", "line": 5, "body": "x"}], "tok")
+        assert out is None
+        assert mock_post.call_count == 1                     # no per-comment fallback on non-422
+
+
+class TestDriverRobustness:
+    """One bad PR must not sink the rest, and the run-lock must be released even on a crash."""
+
+    def _wa(self, prs, preview=False, raise_on=None):
+        store = {}
+        data = {"pull_requests": prs, "github_access_token": "tok", "reviewed_prs": {},
+                "run_lock_token": "T1", "run_lock": {"token": "T1"}}
+        wa = Mock()
+        wa.fetch_data.side_effect = lambda key=None, default=None, run_based=False, **k: data.get(key, default)
+        wa.is_test_run.return_value = preview
+
+        def store_data(*a, **k):
+            key = a[0] if a else k.get("key")
+            val = a[1] if len(a) > 1 else k.get("data")
+            store[key] = val
+            if raise_on and key == raise_on:
+                raise RuntimeError(f"store boom on {key}")
+            return True
+        wa.store_data.side_effect = store_data
+        return wa, store
+
+    def test_post_loop_isolates_bad_pr(self):
+        prs = [{"id": "o/bad", "pr_number": 1, "comment_generated": True, "review_dict": {"findings": []}},
+               {"id": "o/good", "pr_number": 2, "comment_generated": True, "review_dict": {"findings": []}}]
+        wa, store = self._wa(prs, preview=False)
+
+        def fake_process(pr, *a, **k):
+            if pr["id"] == "o/bad":
+                raise RuntimeError("boom in one PR")
+            pr["comment_posted"] = True
+            return True, "http://good", "<block>"
+
+        with patch.object(post_comment, "waveassist", wa), \
+             patch.object(post_comment, "process_one_pr", side_effect=fake_process):
+            run_driver()
+
+        assert prs[1].get("comment_posted") is True          # good PR processed despite the bad one
+        assert store.get("run_lock") == {}                   # lock released in finally
+
+    def test_lock_released_even_when_cleanup_raises(self):
+        prs = [{"id": "o/x", "pr_number": 1, "comment_generated": True, "review_dict": {"findings": []}}]
+        wa, store = self._wa(prs, preview=False, raise_on="display_output")
+
+        def fake_process(pr, *a, **k):
+            pr["comment_posted"] = True
+            return True, "http://x", "<b>"
+
+        with patch.object(post_comment, "waveassist", wa), \
+             patch.object(post_comment, "process_one_pr", side_effect=fake_process), \
+             pytest.raises(RuntimeError):
+            run_driver()                                     # cleanup store raises...
+
+        assert store.get("run_lock") == {}                   # ...but the lock was still released
+
+
+class TestProcessOnePrPartialPost:
+    """Review P2: if inline comments posted but the summary failed, record the ledger anyway so the
+    already-posted inline comments are NOT re-posted as 'new' on the next run (no duplicates)."""
+
+    def test_inline_posted_summary_failed_still_records_ledger(self):
+        pr = {"id": "o/r", "pr_number": 1, "comment_generated": True, "current_sha": "sha",
+              "review_dict": {"verdict": "needs_changes", "findings": [_F()]}}
+        reviewed = {}
+        with patch.object(post_comment, "find_summary_comment_id", return_value=None), \
+             patch.object(post_comment, "create_pr_review", return_value={"id": 99}), \
+             patch.object(post_comment, "create_summary_comment", return_value=None):  # summary FAILS
+            changed, url, block = process_one_pr(pr, reviewed, "tok", preview=False)
+        assert changed is True                          # ledger recorded despite the summary failure
+        assert reviewed.get("o/r#1", {}).get("findings")  # findings persisted -> no re-post next run
+        assert pr.get("comment_posted") is not True     # not fully done; summary retried next cycle

--- a/tests/unit/test_scan_dependencies.py
+++ b/tests/unit/test_scan_dependencies.py
@@ -28,7 +28,10 @@ from scan_dependencies import (
     passes_feed_gate,
     content_hash,
     changed_dependencies,
+    query_osv,
+    fetch_kev_set_with_status,
 )
+import scan_dependencies as sd
 
 
 class TestRequirementsTxt:
@@ -268,3 +271,54 @@ class TestSnapshotDiff:
         assert ("a", "1.1") in changed
         assert ("c", "2.0") in changed
         assert ("b", "1.0") not in changed
+
+
+class _R:
+    def __init__(self, status, payload=None):
+        self.status_code = status
+        self._payload = payload or {}
+    def json(self):
+        return self._payload
+
+
+class TestQueryOsvStatus:
+    """query_osv must report whether the OSV call SUCCEEDED so the driver can tell a clean scan from
+    a feed hiccup (issue #1: never resolve a finding just because a hiccup made it absent)."""
+
+    def test_empty_queries_ok_true(self):
+        hits, ok = query_osv([])
+        assert hits == {} and ok is True            # nothing to query is a clean scan
+
+    def test_http_error_ok_false(self, monkeypatch):
+        monkeypatch.setattr(sd.requests, "post", lambda *a, **k: _R(500))
+        hits, ok = query_osv([{"name": "x", "version": "1", "ecosystem": "PyPI"}])
+        assert hits == {} and ok is False
+
+    def test_exception_ok_false(self, monkeypatch):
+        def boom(*a, **k):
+            raise RuntimeError("network down")
+        monkeypatch.setattr(sd.requests, "post", boom)
+        hits, ok = query_osv([{"name": "x", "version": "1", "ecosystem": "PyPI"}])
+        assert hits == {} and ok is False
+
+    def test_success_returns_hits_and_ok_true(self, monkeypatch):
+        monkeypatch.setattr(sd.requests, "post",
+                            lambda *a, **k: _R(200, {"results": [{"vulns": [{"id": "OSV-1"}]}]}))
+        hits, ok = query_osv([{"name": "requests", "version": "2.31.0", "ecosystem": "PyPI"}])
+        assert ok is True
+        assert hits == {("requests", "2.31.0"): ["OSV-1"]}
+
+
+class TestKevStatus:
+    def test_ok_true_on_200(self, monkeypatch):
+        monkeypatch.setattr(sd.requests, "get",
+                            lambda *a, **k: _R(200, {"vulnerabilities": [{"cveID": "CVE-1"}]}))
+        s, ok = fetch_kev_set_with_status()
+        assert ok is True and "CVE-1" in s
+
+    def test_ok_false_on_failure(self, monkeypatch):
+        def boom(*a, **k):
+            raise RuntimeError("net")
+        monkeypatch.setattr(sd.requests, "get", boom)
+        s, ok = fetch_kev_set_with_status()
+        assert ok is False and s == set()

--- a/tests/unit/test_send_digest.py
+++ b/tests/unit/test_send_digest.py
@@ -117,19 +117,18 @@ class TestBuildEmailHtml:
         assert "SQLi" in html                  # security roll-up rendered
         assert "one" in html                   # poem
 
-    def test_h1_is_brand_not_group_label(self):
+    def test_h1_matches_subject_brand_title(self):
         html = build_email_html(
-            "Acme",
+            "Sacred Walks",
             {"executive_summary": "s", "shipped_features": []},
             {"repository_deep_dive": [], "poem": [],
              "security_rollup": {"counts": {"new": 0, "still_open": 0, "resolved": 0}}},
             {"commits": 1, "contributors": 1, "total_repos": 1, "active_repos": 1},
             {})
-        assert "<h1>Knowledge Digest</h1>" in html
-        assert "<h1>Acme</h1>" not in html          # group label is no longer the H1
-        assert "Acme" in html                        # it moved to the subtitle scope
+        assert "<h1>GitZoid Sacred Walks Digest</h1>" in html   # H1 == the subject's brand title
+        assert "Knowledge Digest" not in html                    # no second, different title
 
-    def test_implicit_group_no_scope_label(self):
+    def test_implicit_group_h1_is_plain_brand(self):
         html = build_email_html(
             "All repositories",
             {"executive_summary": "s", "shipped_features": []},
@@ -137,7 +136,7 @@ class TestBuildEmailHtml:
              "security_rollup": {"counts": {"new": 0, "still_open": 0, "resolved": 0}}},
             {"commits": 1, "contributors": 1, "total_repos": 1, "active_repos": 1},
             {}, implicit=True)
-        assert "<h1>Knowledge Digest</h1>" in html
+        assert "<h1>GitZoid Digest</h1>" in html
         assert "All repositories" not in html
 
     def test_stats_render_as_table_one_row(self):

--- a/tests/unit/test_send_digest.py
+++ b/tests/unit/test_send_digest.py
@@ -1,0 +1,327 @@
+"""
+Unit tests for send_digest.py — the Digest chain's delivery node (node 6, per group).
+
+Adapted from GitDigest's send_emails: combined HTML email + WeasyPrint PDF, but per group (owner
+primary, group recipients CC'd) and with the security roll-up rendered in. It also releases the
+digest_run_lock, token-matched, like triage_and_alert. WeasyPrint is imported lazily so the module
+loads (and these tests run) without it installed; PDF generation soft-fails to no attachment.
+"""
+import sys
+import os
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../')))
+
+from send_digest import (
+    compute_stats,
+    clean_recipients,
+    render_security_rollup_html,
+    build_subject,
+    build_email_html,
+    group_generation_failed,
+)
+
+ROLLUP = {"new": [{"title": "SQLi", "repo": "o/a", "severity": "critical", "actively_exploited": False}],
+          "still_open": [], "resolved": [{"title": "patched dep", "repo": "o/a", "severity": "high",
+                                          "actively_exploited": False}],
+          "counts": {"new": 1, "still_open": 0, "resolved": 1}}
+
+
+class TestComputeStats:
+    ACTIVITY = {
+        "o/a": {"commits": [{"author": "alice"}, {"author": "bob"}], "pull_requests": []},
+        "o/b": {"commits": [], "pull_requests": []},
+        "o/other": {"commits": [{"author": "zed"}], "pull_requests": []},
+    }
+
+    def test_scoped_to_group(self):
+        s = compute_stats(self.ACTIVITY, ["o/a", "o/b"])
+        assert s["commits"] == 2
+        assert s["contributors"] == 2          # alice, bob (zed excluded, o/other not in group)
+        assert s["total_repos"] == 2
+        assert s["active_repos"] == 1          # only o/a had commits
+
+
+class TestCleanRecipients:
+    def test_keeps_valid_emails(self):
+        assert clean_recipients(["a@x.com", "bad", "  b@y.io "]) == ["a@x.com", "b@y.io"]
+
+    def test_empty(self):
+        assert clean_recipients([]) == []
+        assert clean_recipients(None) == []
+
+
+class TestRenderSecurityRollup:
+    def test_lists_new_and_resolved(self):
+        h = render_security_rollup_html(ROLLUP)
+        assert "SQLi" in h
+        assert "patched dep" in h
+
+    def test_clean_week_message(self):
+        h = render_security_rollup_html({"new": [], "still_open": [], "resolved": [],
+                                         "counts": {"new": 0, "still_open": 0, "resolved": 0}})
+        assert "no" in h.lower()               # reassurance, not blank
+
+
+class TestGroupGenerationFailed:
+    def test_business_failure_detected(self):
+        assert group_generation_failed({"generation_failed": True}, {}) is True
+
+    def test_technical_failure_detected(self):
+        assert group_generation_failed({}, {"generation_failed": True}) is True
+
+    def test_clean_reports_not_failed(self):
+        assert group_generation_failed({"executive_summary": "x"}, {"poem": []}) is False
+
+    def test_quiet_week_empty_but_not_failed(self):
+        assert group_generation_failed({"shipped_features": []},
+                                       {"repository_deep_dive": [], "poem": ["..."]}) is False
+
+
+class TestBuildSubject:
+    def test_includes_group(self):
+        assert "Acme" in build_subject("Acme")
+
+    def test_subject_is_branded(self):
+        s = build_subject("Acme", "Jun 15")
+        assert "GitZoid digest" in s
+        assert "Acme" in s
+        assert "week of Jun 15" in s
+
+    def test_implicit_group_subject_has_no_all_repositories(self):
+        s = build_subject("All repositories", "Jun 15", implicit=True)
+        assert "All repositories" not in s
+        assert s == "Your GitZoid digest — week of Jun 15"
+
+    def test_unnamed_group_is_branded(self):
+        s = build_subject("", "Jun 15")
+        assert s == "Your GitZoid digest — week of Jun 15"
+
+    def test_all_repositories_suppressed_even_without_flag(self):
+        s = build_subject("All repositories", "Jun 15")
+        assert "All repositories" not in s
+
+
+class TestBuildEmailHtml:
+    def test_contains_all_sections(self):
+        business = {"executive_summary": "Shipped SSO", "shipped_features": ["SSO login"]}
+        technical = {"repository_deep_dive": [{"repo_name": "o/a", "status": "Feature Dev",
+                                               "technical_changes": ["Added SSO"]}],
+                     "poem": ["one", "two", "three", "four"], "security_rollup": ROLLUP}
+        stats = {"commits": 5, "contributors": 2, "total_repos": 1, "active_repos": 1}
+        html = build_email_html("Acme", business, technical, stats, {})
+        assert "Shipped SSO" in html
+        assert "SSO login" in html
+        assert "o/a" in html
+        assert "Added SSO" in html
+        assert "SQLi" in html                  # security roll-up rendered
+        assert "one" in html                   # poem
+
+    def test_h1_is_brand_not_group_label(self):
+        html = build_email_html(
+            "Acme",
+            {"executive_summary": "s", "shipped_features": []},
+            {"repository_deep_dive": [], "poem": [],
+             "security_rollup": {"counts": {"new": 0, "still_open": 0, "resolved": 0}}},
+            {"commits": 1, "contributors": 1, "total_repos": 1, "active_repos": 1},
+            {})
+        assert "<h1>Knowledge Digest</h1>" in html
+        assert "<h1>Acme</h1>" not in html          # group label is no longer the H1
+        assert "Acme" in html                        # it moved to the subtitle scope
+
+    def test_implicit_group_no_scope_label(self):
+        html = build_email_html(
+            "All repositories",
+            {"executive_summary": "s", "shipped_features": []},
+            {"repository_deep_dive": [], "poem": [],
+             "security_rollup": {"counts": {"new": 0, "still_open": 0, "resolved": 0}}},
+            {"commits": 1, "contributors": 1, "total_repos": 1, "active_repos": 1},
+            {}, implicit=True)
+        assert "<h1>Knowledge Digest</h1>" in html
+        assert "All repositories" not in html
+
+    def test_stats_render_as_table_one_row(self):
+        """Regression: the 4 stats wrapped (3+1) under WeasyPrint flex; a 4-column table keeps them on
+        one row in the PDF and in email clients (both render flexbox unreliably)."""
+        stats = {"commits": 46, "contributors": 6, "total_repos": 2, "active_repos": 2}
+        html = build_email_html("Acme", {"executive_summary": "s", "shipped_features": []},
+                                {"repository_deep_dive": [], "poem": [],
+                                 "security_rollup": {"counts": {"new": 0, "still_open": 0, "resolved": 0}}},
+                                stats, {})
+        style = html.split("</style>")[0]
+        assert '<table class="stats-bar"' in html      # a table, not a flex <div>
+        assert "display: flex" not in style            # flexbox removed from the stats styling
+        for label in ("Commits", "Contributors", "Total Repos", "Active Repos"):
+            assert label in html
+
+
+class TestDriver:
+    def _run(self, monkeypatch, fetch_map):
+        import runpy, waveassist
+        stored, emails = {}, []
+        monkeypatch.setattr(waveassist, "init", lambda *a, **k: None)
+        monkeypatch.setattr(waveassist, "fetch_data",
+                            lambda key=None, default=None, **k: fetch_map.get(key, default))
+        monkeypatch.setattr(waveassist, "store_data",
+                            lambda key, value, **k: stored.__setitem__(key, value))
+        monkeypatch.setattr(waveassist, "send_email",
+                            lambda **k: (emails.append(k) or True))
+        runpy.run_path("send_digest.py", run_name="__main__")
+        return stored, emails
+
+    def test_skip_sends_nothing_but_releases_owned_lock(self, monkeypatch):
+        fetch_map = {
+            "digest_skip_run": "1",
+            "digest_run_lock_token": "TKN",
+            "digest_run_lock": {"at": "now", "token": "TKN"},
+        }
+        stored, emails = self._run(monkeypatch, fetch_map)
+        assert emails == []                              # no email on skip
+        assert stored.get("digest_run_lock") == {}       # but the owned lock is freed
+
+    def test_skip_does_not_free_someone_elses_lock(self, monkeypatch):
+        fetch_map = {
+            "digest_skip_run": "1",
+            "digest_run_lock_token": "",                 # this run never took the lock
+            "digest_run_lock": {"at": "now", "token": "OTHER"},
+        }
+        stored, emails = self._run(monkeypatch, fetch_map)
+        assert "digest_run_lock" not in stored           # holder's lock untouched
+
+    def test_one_email_per_group_with_cc_and_lock_release(self, monkeypatch):
+        groups = [
+            {"name": "Front", "repos": ["o/a"], "recipients": ["lead@acme.com"], "slug": "front"},
+            {"name": "Mobile", "repos": ["o/b"], "recipients": [], "slug": "mobile"},
+        ]
+        fetch_map = {
+            "digest_skip_run": "0",
+            "digest_run_lock_token": "TKN",
+            "digest_run_lock": {"at": "now", "token": "TKN"},
+            "digest_resolved_groups": groups,
+            "digest_business_reports": {"front": {"executive_summary": "s", "shipped_features": []},
+                                        "mobile": {"executive_summary": "s2", "shipped_features": []}},
+            "digest_technical_reports": {"front": {"repository_deep_dive": [], "poem": ["a"], "security_rollup": ROLLUP},
+                                         "mobile": {"repository_deep_dive": [], "poem": ["b"], "security_rollup": ROLLUP}},
+            "github_activity_data": {"o/a": {"commits": [{"author": "x"}]}, "o/b": {"commits": []}},
+            "report_date_range": {},
+            "digest_state": {},
+        }
+        stored, emails = self._run(monkeypatch, fetch_map)
+        assert len(emails) == 2
+        front = next(e for e in emails if "Front" in e["subject"])
+        assert front["cc"] == ["lead@acme.com"]
+        mobile = next(e for e in emails if "Mobile" in e["subject"])
+        assert mobile["cc"] is None                      # no recipients → owner-only
+        assert stored.get("digest_run_lock") == {}        # lock released
+        assert "front" in stored.get("digest_state", {})  # last_sent_at recorded
+
+    def test_failed_group_not_sent(self, monkeypatch):
+        """A group whose LLM raised (generation_failed) is skipped: no email, state untouched. A clean
+        sibling group still sends, and the lock is still released."""
+        groups = [
+            {"name": "Front", "repos": ["o/a"], "recipients": ["lead@acme.com"], "slug": "front"},
+            {"name": "Mobile", "repos": ["o/b"], "recipients": [], "slug": "mobile"},
+        ]
+        fetch_map = {
+            "digest_skip_run": "0",
+            "digest_run_lock_token": "TKN",
+            "digest_run_lock": {"at": "now", "token": "TKN"},
+            "digest_resolved_groups": groups,
+            "digest_business_reports": {
+                "front": {"executive_summary": "s", "shipped_features": [], "generation_failed": True},
+                "mobile": {"executive_summary": "s2", "shipped_features": []}},
+            "digest_technical_reports": {
+                "front": {"repository_deep_dive": [], "poem": [], "security_rollup": ROLLUP},
+                "mobile": {"repository_deep_dive": [], "poem": ["b"], "security_rollup": ROLLUP}},
+            "github_activity_data": {"o/a": {"commits": [{"author": "x"}]}, "o/b": {"commits": []}},
+            "report_date_range": {},
+            "digest_state": {},
+        }
+        stored, emails = self._run(monkeypatch, fetch_map)
+        assert len(emails) == 1
+        assert "Mobile" in emails[0]["subject"]
+        assert all("Front" not in e["subject"] for e in emails)
+        # front's state is never written this run (skipped before digest_state[slug] = state)
+        assert "last_sent_at" not in stored.get("digest_state", {}).get("front", {})
+        assert stored.get("digest_run_lock") == {}             # lock still released
+
+    def test_quiet_week_still_sent(self, monkeypatch):
+        """A genuinely quiet week (empty deterministic reports, NO generation_failed) STILL ships the
+        reassurance email with the security roll-up."""
+        groups = [{"name": "Solo", "repos": ["o/a"], "recipients": [], "slug": "solo"}]
+        fetch_map = {
+            "digest_skip_run": "0",
+            "digest_run_lock_token": "TKN",
+            "digest_run_lock": {"at": "now", "token": "TKN"},
+            "digest_resolved_groups": groups,
+            "digest_business_reports": {
+                "solo": {"executive_summary": "No development activity...", "shipped_features": []}},
+            "digest_technical_reports": {
+                "solo": {"repository_deep_dive": [], "poem": ["q1", "q2", "q3", "q4"],
+                         "security_rollup": ROLLUP}},
+            "github_activity_data": {"o/a": {"commits": []}},
+            "report_date_range": {},
+            "digest_state": {},
+        }
+        stored, emails = self._run(monkeypatch, fetch_map)
+        assert len(emails) == 1
+        assert "SQLi" in emails[0]["html_content"]             # security roll-up present
+
+    def test_all_groups_failed_sends_nothing(self, monkeypatch):
+        """Every group failed → no email at all, but the lock is still released."""
+        groups = [{"name": "Solo", "repos": ["o/a"], "recipients": [], "slug": "solo"}]
+        fetch_map = {
+            "digest_skip_run": "0",
+            "digest_run_lock_token": "TKN",
+            "digest_run_lock": {"at": "now", "token": "TKN"},
+            "digest_resolved_groups": groups,
+            "digest_business_reports": {
+                "solo": {"executive_summary": "s", "shipped_features": [], "generation_failed": True}},
+            "digest_technical_reports": {
+                "solo": {"repository_deep_dive": [], "poem": [], "security_rollup": ROLLUP}},
+            "github_activity_data": {"o/a": {"commits": []}},
+            "report_date_range": {},
+            "digest_state": {},
+        }
+        stored, emails = self._run(monkeypatch, fetch_map)
+        assert emails == []
+        assert stored.get("digest_run_lock") == {}
+
+
+class TestSecurityPoemDivider:
+    """User feedback: on a clean week the SECURITY 'nothing found' line and the poem visually merge —
+    they need a divider between them."""
+
+    def test_divider_sits_between_security_and_poem(self):
+        business = {"executive_summary": "a quiet week", "shipped_features": []}
+        technical = {"repository_deep_dive": [], "poem": ["line one", "line two"],
+                     "security_rollup": {"counts": {"new": 0, "still_open": 0, "resolved": 0}}}
+        html = build_email_html("All repositories", business, technical, {"commits": 0}, {})
+        assert "<hr" in html
+        sec = html.index("SECURITY")
+        poem = html.index("A small poem")
+        hr = html.index("<hr", sec)
+        assert sec < hr < poem            # divider between the security section and the poem
+
+    def test_no_dangling_divider_without_poem(self):
+        business = {"executive_summary": "s", "shipped_features": []}
+        technical = {"repository_deep_dive": [], "poem": [],
+                     "security_rollup": {"counts": {"new": 0, "still_open": 0, "resolved": 0}}}
+        html = build_email_html("All repositories", business, technical, {"commits": 0}, {})
+        assert "A small poem" not in html
+        assert "<hr" not in html           # no poem -> no divider
+
+
+class TestDigestStatus:
+    """Fix B: an all-skipped run (every group's report generation failed) must NOT report success."""
+
+    def test_all_skipped_is_not_success(self):
+        from send_digest import digest_status
+        assert digest_status(sent=0, attempted=0) != "success"
+
+    def test_all_delivered_is_success(self):
+        from send_digest import digest_status
+        assert digest_status(sent=2, attempted=2) == "success"
+
+    def test_partial_delivery_is_email_failed(self):
+        from send_digest import digest_status
+        assert digest_status(sent=1, attempted=2) == "email_failed"

--- a/tests/unit/test_send_digest.py
+++ b/tests/unit/test_send_digest.py
@@ -83,18 +83,19 @@ class TestBuildSubject:
 
     def test_subject_is_branded(self):
         s = build_subject("Acme", "Jun 15")
-        assert "GitZoid digest" in s
-        assert "Acme" in s
-        assert "week of Jun 15" in s
+        assert s == "GitZoid Acme Digest: Week of Jun 15"   # name inside the brand phrase
+
+    def test_named_group_inside_brand_phrase(self):
+        assert build_subject("Sacred Walks", "Jun 15") == "GitZoid Sacred Walks Digest: Week of Jun 15"
 
     def test_implicit_group_subject_has_no_all_repositories(self):
         s = build_subject("All repositories", "Jun 15", implicit=True)
         assert "All repositories" not in s
-        assert s == "Your GitZoid digest — week of Jun 15"
+        assert s == "GitZoid Digest: Week of Jun 15"
 
     def test_unnamed_group_is_branded(self):
         s = build_subject("", "Jun 15")
-        assert s == "Your GitZoid digest — week of Jun 15"
+        assert s == "GitZoid Digest: Week of Jun 15"
 
     def test_all_repositories_suppressed_even_without_flag(self):
         s = build_subject("All repositories", "Jun 15")

--- a/tests/unit/test_triage_and_alert.py
+++ b/tests/unit/test_triage_and_alert.py
@@ -15,10 +15,13 @@ from triage_and_alert import (
     should_escalate,
     reconcile_ledger,
     rank_findings,
+    split_findings,
+    cap_code_findings,
     lock_is_active,
     build_alert_email,
     build_subject,
     parse_recipients,
+    MAX_CODE_ALERTS,
 )
 
 
@@ -49,7 +52,10 @@ class TestCleanOutput:
         ]
 
     def test_email_has_no_emoji_or_emdash(self):
-        out = build_alert_email(self._findings(), scanned_repos=1)
+        fs = self._findings()
+        code = [f for f in fs if f["category"] in ("authz", "secret", "backdoor")]
+        deps = [f for f in fs if f["category"] == "dependency"]
+        out = build_alert_email(code, deps, scanned_repos=1)
         for ch in EMOJI:
             assert ch not in out, f"email should not contain {ch!r}"
 
@@ -60,7 +66,10 @@ class TestCleanOutput:
         assert "GitZoid Security" in subj
 
     def test_email_still_shows_fix_and_severity(self):
-        out = build_alert_email(self._findings(), scanned_repos=1)
+        fs = self._findings()
+        code = [f for f in fs if f["category"] in ("authz", "secret", "backdoor")]
+        deps = [f for f in fs if f["category"] == "dependency"]
+        out = build_alert_email(code, deps, scanned_repos=1)
         assert "Fix:" in out
         assert "Severity: High" in out
 
@@ -159,15 +168,16 @@ class TestReconcile:
         assert ledger[finding_sig(_dep())]["severity"] == "critical"
 
     def test_disappeared_finding_marked_resolved(self):
+        # Resolution now requires the repo to have been SCANNED OK this run (absence alone is not a fix).
         first, _, _ = reconcile_ledger({}, [_dep()])
-        ledger, to_alert, resolved = reconcile_ledger(first, [])   # gone this run
+        ledger, to_alert, resolved = reconcile_ledger(first, [], scanned_ok_deps={"o/r"})   # gone, repo scanned
         assert len(resolved) == 1
         assert to_alert == []                              # resolutions are NOT emailed
         assert ledger[finding_sig(_dep())]["status"] == "resolved"
 
     def test_resolved_then_reappears_is_open_again(self):
         first, _, _ = reconcile_ledger({}, [_dep()])
-        gone, _, _ = reconcile_ledger(first, [])
+        gone, _, _ = reconcile_ledger(first, [], scanned_ok_deps={"o/r"})
         back, to_alert, resolved = reconcile_ledger(gone, [_dep()])
         assert back[finding_sig(_dep())]["status"] == "open"
         assert len(to_alert) == 1                          # came back → alert again
@@ -238,3 +248,225 @@ class TestDriver:
             "security_findings": {}, "github_selected_resources": [{"id": "o/r"}]})
         assert sent == []                                # silence is the all-clear
         assert "display_output" in stored               # but the run still reports it scanned
+
+
+class TestReconcileScannedOk:
+    """Issue #1 (repeated emails): only RESOLVE a finding when its repo was actually scanned OK this
+    run. Absence from a feed/GitHub/LLM hiccup must carry the finding forward, not resolve+re-alert."""
+
+    def test_no_resolve_on_unscanned_repo(self):
+        first, _, _ = reconcile_ledger({}, [_dep()])
+        ledger, to_alert, resolved = reconcile_ledger(first, [], scanned_ok_deps=set())   # feed hiccup
+        assert resolved == []
+        assert ledger[finding_sig(_dep())]["status"] == "open"
+
+    def test_resolve_only_when_repo_scanned(self):
+        first, _, _ = reconcile_ledger({}, [_dep()])
+        ledger, to_alert, resolved = reconcile_ledger(first, [], scanned_ok_deps={"o/r"})
+        assert len(resolved) == 1
+        assert ledger[finding_sig(_dep())]["status"] == "resolved"
+
+    def test_unscanned_other_repo_does_not_resolve_target(self):
+        first, _, _ = reconcile_ledger({}, [_dep(repo="o/a")])
+        ledger, to_alert, resolved = reconcile_ledger(first, [], scanned_ok_deps={"o/b"})
+        assert resolved == []
+        assert ledger[finding_sig(_dep(repo="o/a"))]["status"] == "open"
+
+    def test_no_realert_after_feed_hiccup(self):
+        first, _, _ = reconcile_ledger({}, [_dep()])
+        # feed failed: finding absent, repo NOT scanned ok -> carried forward, not resolved
+        hiccup, to_alert, resolved = reconcile_ledger(first, [], scanned_ok_deps=set())
+        assert to_alert == [] and resolved == []
+        # next run recovers, same finding present -> it was never resolved, so NO re-alert
+        back, to_alert2, _ = reconcile_ledger(hiccup, [_dep()], scanned_ok_deps={"o/r"})
+        assert to_alert2 == []
+
+
+class TestSeverityAndFixFlap:
+    """Flapping feed severity / fix-availability must re-alert at most ONCE, not every cycle."""
+
+    def test_no_realert_on_severity_flap(self):
+        l1, _, _ = reconcile_ledger({}, [_dep(severity="high", fixed=None)])
+        l2, a2, _ = reconcile_ledger(l1, [_dep(severity="critical", fixed=None)], scanned_ok_deps={"o/r"})
+        assert len(a2) == 1
+        assert l2[finding_sig(_dep())]["max_alerted_severity"] == "critical"
+        l3, a3, _ = reconcile_ledger(l2, [_dep(severity="high", fixed=None)], scanned_ok_deps={"o/r"})
+        assert a3 == []                                    # high < critical hwm -> no re-alert
+        l4, a4, _ = reconcile_ledger(l3, [_dep(severity="critical", fixed=None)], scanned_ok_deps={"o/r"})
+        assert a4 == []                                    # back to critical, still at hwm -> no re-alert
+
+    def test_no_realert_on_fix_flap(self):
+        l1, _, _ = reconcile_ledger({}, [_dep(fixed=None)])
+        l2, a2, _ = reconcile_ledger(l1, [_dep(fixed="1.0.1")], scanned_ok_deps={"o/r"})
+        assert len(a2) == 1
+        assert l2[finding_sig(_dep())]["fix_alerted"] is True
+        l3, a3, _ = reconcile_ledger(l2, [_dep(fixed=None)], scanned_ok_deps={"o/r"})
+        assert a3 == []                                    # fix field cleared -> no re-alert
+        l4, a4, _ = reconcile_ledger(l3, [_dep(fixed="1.0.1")], scanned_ok_deps={"o/r"})
+        assert a4 == []                                    # fix reappears -> already alerted, no re-alert
+
+    def test_max_alerted_severity_and_fix_alerted_seeded(self):
+        ledger, _, _ = reconcile_ledger({}, [_dep(severity="high", fixed="1.0.1")])
+        e = ledger[finding_sig(_dep())]
+        assert e["max_alerted_severity"] == "high"
+        assert e["fix_alerted"] is True
+        ledger2, _, _ = reconcile_ledger({}, [_dep(fixed=None)])
+        assert ledger2[finding_sig(_dep())]["fix_alerted"] is False
+
+
+class TestSeparation:
+    """Issue #4: code/access issues and dependencies render in their own labelled sections, and
+    dependencies are NEVER capped (issue #1: report them all at once)."""
+
+    def _code(self):
+        return {"category": "authz", "repo": "o/r", "title": "Bypassable check: /acl/list",
+                "severity": "high", "named_victim": "any user", "fix": "add authorize_admin",
+                "impact": "reads any user's data", "entry_point": "/acl/list"}
+
+    def _dep_f(self, name="litellm"):
+        return {"category": "dependency", "repo": "o/r", "name": name, "version": "1.0",
+                "vuln_id": "CVE-1", "severity": "high", "fix": "1.1", "impact": "leaks keys"}
+
+    def test_email_has_two_labelled_sections_code_first(self):
+        out = build_alert_email([self._code()], [self._dep_f()], scanned_repos=2)
+        assert "Code and access issues" in out
+        assert "Vulnerable dependencies" in out
+        assert out.index("Code and access issues") < out.index("Vulnerable dependencies")
+        for ch in EMOJI:
+            assert ch not in out
+
+    def test_code_section_omitted_when_empty(self):
+        out = build_alert_email([], [self._dep_f()], scanned_repos=1)
+        assert "Code and access issues" not in out
+        assert "Vulnerable dependencies" in out
+
+    def test_all_dep_findings_sent_not_capped(self):
+        deps = [self._dep_f(name=f"pkg{i}") for i in range(20)]
+        out = build_alert_email([], deps, scanned_repos=1)
+        assert all(f"pkg{i}" in out for i in range(20))     # no dependency cap
+
+    def test_code_cap_applied_but_kev_kept(self):
+        code = []
+        for i in range(8):
+            f = self._code()
+            f = {**f, "entry_point": f"/r{i}", "title": f"issue {i}", "severity": "low",
+                 "actively_exploited": (i == 7)}      # the LAST one is KEV and lowest priority
+            code.append(f)
+        kept = cap_code_findings(code)
+        assert any(f.get("actively_exploited") for f in kept)   # KEV one survives the cap
+        non_kev = [f for f in kept if not f.get("actively_exploited")]
+        assert len(non_kev) <= MAX_CODE_ALERTS
+
+
+class TestScannedOkCategoryScoped:
+    """REGRESSION (review P0): a daily dependency-only scan must NOT resolve an un-re-audited CODE
+    finding (authz/secret/backdoor). Code findings resolve only against scanned_ok_code (weekly
+    audit); dependency findings only against scanned_ok_deps."""
+
+    def _authz(self, repo="o/r"):
+        return {"category": "authz", "repo": repo, "dedup_key": "authz:/acl/list",
+                "title": "Bypassable check: /acl/list", "severity": "high",
+                "impact": "reads any user's data"}
+
+    def test_dep_scan_does_not_resolve_code_finding(self):
+        first, _, _ = reconcile_ledger({}, [self._authz()])
+        # daily dep scan ran clean for o/r, but the code was NOT audited this run
+        ledger, to_alert, resolved = reconcile_ledger(first, [], scanned_ok_deps={"o/r"},
+                                                      scanned_ok_code=set())
+        assert resolved == []
+        assert ledger[finding_sig(self._authz())]["status"] == "open"
+
+    def test_code_scan_resolves_code_finding(self):
+        first, _, _ = reconcile_ledger({}, [self._authz()])
+        ledger, to_alert, resolved = reconcile_ledger(first, [], scanned_ok_code={"o/r"})
+        assert len(resolved) == 1
+        assert ledger[finding_sig(self._authz())]["status"] == "resolved"
+
+    def test_code_scan_does_not_resolve_dependency_finding(self):
+        first, _, _ = reconcile_ledger({}, [_dep()])
+        # weekly audit ran (code), but deps were not scanned this run
+        ledger, to_alert, resolved = reconcile_ledger(first, [], scanned_ok_code={"o/r"},
+                                                      scanned_ok_deps=set())
+        assert resolved == []
+        assert ledger[finding_sig(_dep())]["status"] == "open"
+
+
+class TestDependencyGrouping:
+    """Real-world fix: many CVEs for the SAME package must consolidate into ONE block with ONE
+    upgrade target, not a dozen near-identical entries with conflicting 'upgrade to X' advice."""
+
+    def _cve(self, vuln_id, severity, fix, impact="some impact"):
+        return {"category": "dependency", "repo": "o/r", "name": "Django", "version": "4.2",
+                "vuln_id": vuln_id, "severity": severity, "fix": fix, "impact": impact}
+
+    def test_same_package_consolidated_into_one_block(self):
+        deps = [
+            self._cve("GHSA-1", "critical", "5.2.8", "sql injection"),
+            self._cve("GHSA-2", "high", "4.2.24", "denial of service"),
+            self._cve("GHSA-3", "high", "6.0.4", "path traversal"),
+        ]
+        out = build_alert_email([], deps, scanned_repos=1)
+        assert out.count("Django 4.2") == 1                      # one block, not three
+        assert "3 known vulnerabilities" in out                  # the count
+        assert "upgrade Django to 6.0.4 or later" in out         # single target = highest fixed version
+        assert "Severity: Critical" in out                       # worst severity surfaced
+        for ref in ("GHSA-1", "GHSA-2", "GHSA-3"):
+            assert ref in out                                    # every advisory still referenced
+
+    def test_distinct_packages_stay_separate(self):
+        deps = [self._cve("GHSA-1", "high", "5.2.8"),
+                {"category": "dependency", "repo": "o/r", "name": "authlib", "version": "1.6.4",
+                 "vuln_id": "GHSA-9", "severity": "high", "fix": "1.6.5", "impact": "dos"}]
+        out = build_alert_email([], deps, scanned_repos=1)
+        assert "Django 4.2" in out and "authlib 1.6.4" in out
+
+    def test_no_fixed_version_group(self):
+        deps = [self._cve("GHSA-1", "high", None), self._cve("GHSA-2", "high", None)]
+        out = build_alert_email([], deps, scanned_repos=1)
+        assert "No fixed version" in out
+
+
+class TestIssueCountGrouped:
+    """The header/subject 'N issues' must count GROUPED issues (a package = 1), not raw CVEs —
+    so 12 Django advisories shown as one block count as one issue, not twelve."""
+
+    def _cve(self, vid, sev, fix):
+        return {"category": "dependency", "repo": "o/r", "name": "Django", "version": "4.2",
+                "vuln_id": vid, "severity": sev, "fix": fix, "impact": "x"}
+
+    def test_header_and_subject_count_packages_not_cves(self):
+        code = [{"category": "authz", "repo": "o/r", "title": "A", "severity": "high", "impact": "x"},
+                {"category": "secret", "repo": "o/r", "title": "B", "severity": "high", "impact": "x"}]
+        deps = [self._cve("GHSA-1", "critical", "5.2.8"),
+                self._cve("GHSA-2", "high", "4.2.24"),
+                self._cve("GHSA-3", "high", "6.0.4")]      # 3 Django CVEs = ONE package
+        out = build_alert_email(code, deps, scanned_repos=2)
+        assert "3 issues found" in out                     # 2 code + 1 Django package
+        assert "5 issues" not in out                       # not the raw 2+3
+        subj = build_subject(code + deps)
+        assert "3 issues" in subj
+
+    def test_single_issue_singular_wording(self):
+        out = build_alert_email([], [self._cve("GHSA-1", "high", "5.0.7")], scanned_repos=1)
+        assert "1 issue found" in out and "1 issues" not in out
+
+
+class TestSubjectMultiRepo:
+    """Fix D: when findings span multiple repos the subject must not name just one repo."""
+
+    def _f(self, repo, sev="high", **kw):
+        return {"category": "authz", "repo": repo, "title": f"bug in {repo}",
+                "severity": sev, "impact": "x", **kw}
+
+    def test_single_repo_names_the_repo(self):
+        s = build_subject([self._f("o/r")])
+        assert "in o/r" in s
+
+    def test_multi_repo_says_count_of_repos(self):
+        s = build_subject([self._f("o/a"), self._f("o/b")])
+        assert "2 repositories" in s
+        assert "GitZoid Security" in s
+
+    def test_kev_multi_repo_mentions_more(self):
+        s = build_subject([self._f("o/a", actively_exploited=True), self._f("o/b")])
+        assert "actively exploited" in s and "more" in s

--- a/triage_and_alert.py
+++ b/triage_and_alert.py
@@ -23,7 +23,7 @@ import waveassist
 
 waveassist.init()   # credits gated once upstream in security_check_and_init
 
-MAX_ALERTS = 5
+MAX_CODE_ALERTS = 5     # cap on the code/access section only; dependencies are listed in full (issue #1)
 MAX_RESOLVED_KEPT = 60
 LEDGER_KEY = "security_findings"
 RUN_LOCK_KEY = "security_run_lock"
@@ -66,34 +66,50 @@ def finding_sig(f) -> str:
 
 
 def should_escalate(prior: dict, new: dict) -> bool:
-    """Re-alert an already-seen finding only if it got worse: severity rose, or a fix is now
-    published where there wasn't one before."""
-    prior_sev = _SEV_RANK.get(prior.get("severity"), 4)
-    new_sev = _SEV_RANK.get(new.get("severity"), 4)
-    if new_sev < prior_sev:                      # lower rank number = more severe
+    """Re-alert an already-seen finding only if it got genuinely worse than the worst we ALREADY
+    alerted. Comparing against the high-water mark `max_alerted_severity` (not the last-seen
+    severity) means a feed flapping high<->critical re-alerts at most once; once we have alerted that
+    a fix exists (`fix_alerted`), a later fix-field flicker never re-alerts. Legacy entries without
+    these keys fall back to the old fields, so they self-heal."""
+    hwm = prior.get("max_alerted_severity", prior.get("severity"))
+    if _SEV_RANK.get(new.get("severity"), 4) < _SEV_RANK.get(hwm, 4):   # lower rank = more severe
         return True
-    if not prior.get("fixed") and new.get("fixed"):
+    already_alerted_fix = prior.get("fix_alerted", bool(prior.get("fixed")))
+    if not already_alerted_fix and new.get("fixed"):
         return True
     return False
 
 
 def _entry_from(f, sig, now_iso):
     return {"sig": sig, "category": f.get("category"), "repo": f.get("repo"),
-            "name": f.get("name"), "path": f.get("path"), "entry_point": f.get("entry_point"),
-            "title": f.get("title"), "vuln_id": f.get("vuln_id"), "dedup_key": f.get("dedup_key"),
+            "name": f.get("name"), "version": f.get("version"),
+            "path": f.get("path"), "entry_point": f.get("entry_point"),
+            "title": f.get("title"), "vuln_id": f.get("vuln_id"),
+            "aliases": f.get("aliases") or [], "dedup_key": f.get("dedup_key"),
+            "named_victim": f.get("named_victim"),
             "severity": f.get("severity"), "fixed": f.get("fixed"),
             "actively_exploited": f.get("actively_exploited", False),
             "impact": f.get("impact") or f.get("summary") or "",
             "fix": f.get("fix") or f.get("fixed") or "",
+            "max_alerted_severity": f.get("severity"),       # high-water mark for escalation
+            "fix_alerted": bool(f.get("fixed")),             # have we already alerted a fix?
             "status": "open", "alerted": True,
             "first_seen": now_iso, "last_seen": now_iso}
 
 
-def reconcile_ledger(prior_ledger, candidates, now=None):
+def reconcile_ledger(prior_ledger, candidates, scanned_ok_deps=None, scanned_ok_code=None, now=None):
     """Returns (new_ledger, to_alert, resolved). Alert new or reappeared findings and escalations;
-    carry unchanged ones silently; mark currently-open findings that disappeared as resolved."""
+    carry unchanged ones silently; mark a currently-open finding resolved ONLY when its OWN class was
+    actually re-checked this run — a dependency finding resolves only when its repo is in
+    `scanned_ok_deps` (the daily dep scan ran clean), a code finding (authz/secret/backdoor) only when
+    its repo is in `scanned_ok_code` (the weekly deep audit ran). This is category-scoped on purpose:
+    a daily dependency scan must NOT silently resolve an un-re-examined auth hole (which would then
+    re-alert at the next weekly audit — the very churn issue #1 is about). Absence with no matching
+    scan carries the finding forward."""
     now_iso = (now or datetime.now(timezone.utc)).isoformat()
     new_ledger = {k: dict(v) for k, v in (prior_ledger or {}).items()}
+    ok_deps = set(scanned_ok_deps or [])
+    ok_code = set(scanned_ok_code or [])
     current_sigs, to_alert = set(), []
 
     for f in (candidates or []):
@@ -107,10 +123,17 @@ def reconcile_ledger(prior_ledger, candidates, now=None):
             new_ledger[sig] = entry
             to_alert.append(entry)
         elif should_escalate(prior, f):
-            prior.update({"severity": f.get("severity"), "fixed": f.get("fixed"),
+            new_sev = f.get("severity")
+            prior.update({"severity": new_sev, "fixed": f.get("fixed"),
                           "actively_exploited": f.get("actively_exploited", prior.get("actively_exploited")),
                           "impact": f.get("impact") or prior.get("impact"),
                           "status": "open", "alerted": True, "last_seen": now_iso})
+            # raise the high-water mark and record that a fix was alerted, so a later flap is quiet
+            hwm = prior.get("max_alerted_severity", new_sev)
+            if _SEV_RANK.get(new_sev, 4) < _SEV_RANK.get(hwm, 4):
+                prior["max_alerted_severity"] = new_sev
+            if f.get("fixed"):
+                prior["fix_alerted"] = True
             to_alert.append(prior)
         else:
             prior["last_seen"] = now_iso
@@ -118,7 +141,12 @@ def reconcile_ledger(prior_ledger, candidates, now=None):
 
     resolved = []
     for sig, entry in new_ledger.items():
-        if entry.get("status") == "open" and sig not in current_sigs:
+        if entry.get("status") != "open" or sig in current_sigs:
+            continue
+        repo = entry.get("repo")
+        is_code = entry.get("category") in _CODE_CATEGORIES
+        rescanned = (repo in ok_code) if is_code else (repo in ok_deps)
+        if rescanned:                      # only resolve when this finding's OWN class was re-checked
             entry["status"] = "resolved"
             entry["resolved_at"] = now_iso
             resolved.append(entry)
@@ -189,14 +217,116 @@ def _finding_block(f) -> str:
             f"<div style='margin-top:4px'>{impact}</div>{victim_line}{fix_line}{where_line}</div>")
 
 
-def build_alert_email(findings, scanned_repos):
-    """Owner-facing HTML for the consolidated alert. findings already ranked + capped."""
-    n = len(findings)
+def split_findings(findings):
+    """Partition findings into (code, deps). Code = authz/secret/backdoor (the exploitable-code
+    issues); deps = vulnerable dependencies. They render in separate labelled sections so a real
+    auth hole is never visually buried among routine dependency CVEs (issue #4)."""
+    code = [f for f in findings if f.get("category") in _CODE_CATEGORIES]
+    deps = [f for f in findings if f.get("category") not in _CODE_CATEGORIES]
+    return code, deps
+
+
+def cap_code_findings(code):
+    """Cap the code/access section at MAX_CODE_ALERTS, but NEVER drop an actively-exploited (KEV)
+    finding — those always make the cut. Dependencies are not passed here: they are listed in full."""
+    kept = [f for f in code if f.get("actively_exploited")]
+    for f in code:
+        if not f.get("actively_exploited") and len(kept) < MAX_CODE_ALERTS:
+            kept.append(f)
+    return rank_findings(kept)
+
+
+def _section(title, findings):
+    if not findings:
+        return ""
+    blocks = "".join(_finding_block(f) for f in findings)
+    return f"<h3 style='margin:18px 0 2px;font-size:14px;color:#374151'>{html.escape(title)}</h3>" + blocks
+
+
+def _max_version(versions):
+    """Highest version among a package's fix targets (numeric-tuple compare). A package with many
+    advisories then shows ONE upgrade target ('upgrade to the highest fixed version') instead of a
+    dozen conflicting ones."""
+    def key(v):
+        return [int(p) for p in re.findall(r"\d+", str(v or ""))]
+    vs = [v for v in versions if v]
+    return max(vs, key=key) if vs else None
+
+
+def _dep_group_block(group):
+    """One block for ALL advisories affecting the same (repo, package, version). Shows the worst
+    severity, a count, the single recommended upgrade, the worst-case impact, and every reference —
+    so 13 Django CVEs read as one 'Django 4.2 — 13 issues, upgrade to X' entry, not 13 conflicting ones."""
+    by_sev = sorted(group, key=lambda g: _SEV_RANK.get(g.get("severity"), 4))
+    worst = by_sev[0]
+    repo = html.escape(str(worst.get("repo") or ""))
+    sev = _SEV_LABEL.get(worst.get("severity"), "")
+    kev = "<b>Actively exploited in the wild</b>" if any(g.get("actively_exploited") for g in group) else ""
+    name = worst.get("name") or ""
+    pkg = html.escape(f"{name} {worst.get('version') or ''}".strip())
+    n = len(group)
+    count_line = (f"<div style='color:#666;font-size:12px;margin-top:2px'>{n} known vulnerabilities</div>"
+                  if n > 1 else "")
+    impact = html.escape(str(worst.get("impact") or worst.get("summary") or ""))
+    target = _max_version([g.get("fix") or g.get("fixed") for g in group])
+    if target:
+        more = f" (resolves {n} advisories)" if n > 1 else ""
+        fix_line = (f"<div style='color:#1b5e20;margin-top:4px'>Fix: upgrade {html.escape(str(name))} to "
+                    f"{html.escape(str(target))} or later{more}.</div>")
+    else:
+        fix_line = "<div style='color:#8a6d3b;margin-top:4px'>No fixed version is published yet.</div>"
+    refs = []
+    for g in group:
+        r = g.get("vuln_id") or ", ".join(g.get("aliases") or [])
+        if r:
+            refs.append(r)
+    refs = list(dict.fromkeys(refs))   # de-dupe, keep order
+    ref_line = (f"<div style='color:#888;font-size:11px;margin-top:4px'>"
+                f"{'References' if len(refs) > 1 else 'Reference'}: {html.escape(', '.join(refs))}</div>"
+                if refs else "")
+    header = _meta_line([f"<b>{repo}</b>", html.escape(f"Severity: {sev}") if sev else "", kev])
+    return (f"<div style='margin:12px 0;padding:11px 13px;border-left:4px solid #b91c1c;background:#fbf6f6'>"
+            f"<div>{header}</div>"
+            f"<div style='font-weight:600;margin-top:3px'>{pkg}</div>{count_line}"
+            f"<div style='margin-top:4px'>{impact}</div>{fix_line}{ref_line}</div>")
+
+
+def _dep_section(dep_findings):
+    """The 'Vulnerable dependencies' section, grouped one block per (repo, package, version) so the
+    same package's many advisories consolidate instead of repeating with conflicting fixes (issue #1)."""
+    if not dep_findings:
+        return ""
+    groups, order = {}, []
+    for f in dep_findings:
+        k = (f.get("repo"), f.get("name"), f.get("version"))
+        if k not in groups:
+            groups[k] = []
+            order.append(k)
+        groups[k].append(f)
+    blocks = "".join(_dep_group_block(groups[k]) for k in order)
+    return "<h3 style='margin:18px 0 2px;font-size:14px;color:#374151'>Vulnerable dependencies</h3>" + blocks
+
+
+def _issue_count(findings):
+    """Count issues the way the email DISPLAYS them: each code finding is one issue; each vulnerable
+    dependency PACKAGE (repo, name, version) is ONE issue no matter how many advisories it carries.
+    So 12 Django CVEs shown as one block count as one issue, not twelve."""
+    code = sum(1 for f in (findings or []) if f.get("category") in _CODE_CATEGORIES)
+    dep_pkgs = {(f.get("repo"), f.get("name"), f.get("version"))
+                for f in (findings or []) if f.get("category") not in _CODE_CATEGORIES}
+    return code + len(dep_pkgs)
+
+
+def build_alert_email(code_findings, dep_findings, scanned_repos):
+    """Owner-facing HTML for the consolidated alert. Two labelled sections: code/access issues on
+    top (rarer, more serious), then vulnerable dependencies below. code_findings is already ranked +
+    capped; dep_findings is listed in full (no cap — issue #1)."""
+    n = _issue_count(code_findings + dep_findings)
     head = (f"<div style=\"font-family:-apple-system,Segoe UI,sans-serif;padding:16px;line-height:1.5;color:#1f2937\">"
             f"<h2 style='margin:0 0 4px;font-size:18px'>GitZoid Security Review</h2>"
             f"<div style='color:#666;font-size:12px'>{n} issue{'s' if n != 1 else ''} found across {scanned_repos} "
             f"repositor{'ies' if scanned_repos != 1 else 'y'}. Only real, exploitable issues are shown.</div>")
-    body = "".join(_finding_block(f) for f in findings)
+    body = _section("Code and access issues", code_findings) + _dep_section(dep_findings)
     foot = ("<div style='margin-top:14px;color:#888;font-size:11px'>"
             "GitZoid stays silent unless it finds something real, and will not re-alert you about an "
             "issue you have already seen.</div></div>")
@@ -205,11 +335,14 @@ def build_alert_email(findings, scanned_repos):
 
 def build_subject(findings):
     top = findings[0]
-    where = top.get("repo") or "your repos"
-    n = len(findings)
+    repos = {f.get("repo") for f in findings if f.get("repo")}
+    multi = len(repos) > 1
+    n = _issue_count(findings)              # count grouped issues (a package = 1), not raw CVEs
     count = f"{n} issues" if n != 1 else "1 issue"
     if top.get("actively_exploited"):
+        where = (top.get("repo") or "your repos") + (f" and {len(repos) - 1} more" if multi else "")
         return f"GitZoid Security: actively exploited issue in {where}"
+    where = f"{len(repos)} repositories" if multi else (top.get("repo") or "your repos")
     return f"GitZoid Security: {count} in {where}"
 
 
@@ -240,7 +373,11 @@ skip = waveassist.fetch_data("security_skip_run", run_based=True, default="0") =
 if not skip:
     candidates = waveassist.fetch_data("security_candidates", run_based=True, default=[]) or []
     prior_ledger = waveassist.fetch_data(LEDGER_KEY, default={}) or {}
-    new_ledger, to_alert, resolved = reconcile_ledger(prior_ledger, candidates)
+    scanned_ok_deps = waveassist.fetch_data("security_scanned_ok_deps", run_based=True, default=[]) or []
+    scanned_ok_code = waveassist.fetch_data("security_scanned_ok_code", run_based=True, default=[]) or []
+    new_ledger, to_alert, resolved = reconcile_ledger(prior_ledger, candidates,
+                                                      scanned_ok_deps=scanned_ok_deps,
+                                                      scanned_ok_code=scanned_ok_code)
 
     repositories = waveassist.fetch_data("github_selected_resources", default=[]) or []
     scanned_repos = len(repositories) if isinstance(repositories, list) else 0
@@ -254,9 +391,12 @@ if not skip:
         preview = False
 
     if to_alert:
-        ranked = rank_findings(to_alert)[:MAX_ALERTS]
-        subject = build_subject(ranked)
-        email_html = build_alert_email(ranked, scanned_repos)
+        ranked = rank_findings(to_alert)
+        code, deps = split_findings(ranked)
+        kept_code = cap_code_findings(code)          # cap code section, keep KEV; deps listed in full
+        displayed = rank_findings(kept_code + deps)  # exactly what the email body shows
+        subject = build_subject(displayed)           # subject + count agree with the rendered body
+        email_html = build_alert_email(kept_code, deps, scanned_repos)
         # Owner is always the primary recipient (SDK); configured extras are CC'd.
         cc = parse_recipients(waveassist.fetch_data("security_recipients", default="") or "")
         if not preview:
@@ -267,7 +407,7 @@ if not skip:
                 print(f"⚠️ security alert email failed: {e}")
         waveassist.store_data("display_output", {"html_content": email_html},
                               run_based=True, data_type="json")
-        print(f"GitZoid Security: alerted {len(ranked)} finding(s); {len(resolved)} resolved.")
+        print(f"GitZoid Security: alerted {_issue_count(displayed)} issue(s); {len(resolved)} resolved.")
     else:
         msg = (f"<p>GitZoid scanned {scanned_repos} repo(s) — nothing new to report. "
                f"{len(resolved)} issue(s) resolved since last time.</p>")


### PR DESCRIPTION
Adds the weekly Knowledge Digest chain as a third disconnected subgraph (digest_check_and_init, fetch_activity, analyze_activity, generate_business_report, generate_technical_report, send_digest) plus config (enable_digest, digest_groups).

Hardening across the assistant:
- Security alerts: report ALL dependency findings (no 5-cap), grouped by package into one block; two labelled sections (code/access vs deps); resolve only on a successful same-class scan (scanned_ok deps/code) so feed/LLM hiccups no longer churn/re-alert; escalate against a high-water mark + fix_alerted; realism decided once per finding. Issue count and subject reflect grouped packages and multi-repo scope.
- Digest: never send a broken email on generation failure (no fallback poem); branded subject/title; group dependencies in the security roll-up to match the alert; divider before the poem; non-success status when all groups fail.
- PR review posting: per-PR isolation, run-lock released in try/finally, 422 per-comment fallback, None-safe rendering, fail-open verify.

448 unit + integration tests pass.