### PR TITLE
Update digest generation and security email

### DIFF
--- a/analyze_activity.py
+++ b/analyze_activity.py
@@ -36,7 +36,6 @@ print("GitZoid Digest: starting repository activity analysis (analyze_activity) 
 # Haiku to save credits and shorten the (slow, per-repo) digest run.
 DEFAULT_MODEL = "anthropic/claude-haiku-4.5"
 MAX_TOKENS = 8000   # reasoning/"pro" models spend this on hidden reasoning too
-TEMPERATURE = 0.4
 RATE_SLEEP = 0.5
 HTTP_TIMEOUT = 20
 GITHUB_API = "https://api.github.com"
@@ -241,7 +240,7 @@ Guidelines:
     for i in range(attempts):
         try:
             return waveassist.call_llm(model=model_name, prompt=prompt, response_model=RepositoryAnalysis,
-                                       max_tokens=MAX_TOKENS, temperature=TEMPERATURE)
+                                       max_tokens=MAX_TOKENS)
         except Exception as e:
             print(f"⚠️ analysis LLM attempt {i + 1}/{attempts} failed for {repo_path}: {e}")
             if i < attempts - 1:

--- a/generate_business_report.py
+++ b/generate_business_report.py
@@ -25,7 +25,6 @@ print("GitZoid Digest: starting business report generation (generate_business_re
 
 DEFAULT_MODEL = "anthropic/claude-sonnet-4.6"
 MAX_TOKENS = 8000   # reasoning/"pro" models spend this on hidden reasoning too
-TEMPERATURE = 0.4
 
 
 class BusinessReport(BaseModel):
@@ -181,7 +180,7 @@ if groups:
                               brain_block(profiles))
         try:
             result = waveassist.call_llm(model=model_name, prompt=prompt, response_model=BusinessReport,
-                                         max_tokens=MAX_TOKENS, temperature=TEMPERATURE)
+                                         max_tokens=MAX_TOKENS)
         except Exception as e:
             print(f"⚠️ business LLM failed for {slug}: {e}")
             result = None

--- a/generate_technical_report.py
+++ b/generate_technical_report.py
@@ -24,7 +24,6 @@ print("GitZoid Digest: starting technical report generation (generate_technical_
 
 DEFAULT_MODEL = "anthropic/claude-sonnet-4.6"
 MAX_TOKENS = 8000   # reasoning/"pro" models spend this on hidden reasoning too
-TEMPERATURE = 0.4
 ROLLUP_WINDOW_DAYS = 7
 _SEV_RANK = {"critical": 0, "high": 1, "medium": 2, "low": 3, "unknown": 4}
 
@@ -150,6 +149,20 @@ def security_rollup(ledger, group_repos, now, days=ROLLUP_WINDOW_DAYS):
             "counts": {"new": len(new), "still_open": len(still_open), "resolved": len(resolved)}}
 
 
+def group_scanned(group_repos):
+    """True iff Security Watch has actually scanned at least one of this group's repos — i.e. a
+    `dependency_snapshot:{repo}` exists (scan_dependencies writes one for every repo it processes).
+    An empty roll-up then means one of two very different things: a genuine clean week (scanned,
+    found nothing) OR 'not scanned yet' (e.g. the very first digest firing before Security Watch has
+    run, or a digest-group repo that no security group covers). Only the former is a trustworthy
+    all-clear; the latter is a false one that would contradict the first security alert email. This
+    flag lets send_digest hide the section until a scan has genuinely happened."""
+    for r in (group_repos or []):
+        if waveassist.fetch_data(f"dependency_snapshot:{r}", default=None):
+            return True
+    return False
+
+
 def build_prompt(project_name, changes_context, business_report_context, brain_context) -> str:
     parts = [
         ("You are a technical advisor reporting to a busy CTO. "
@@ -211,6 +224,7 @@ if groups:
         repos = group.get("repos") or []
         analyses = filter_analyses(repository_analyses, repos)
         rollup = security_rollup(ledger, repos, now)
+        rollup["scanned"] = group_scanned(repos)   # distinguishes a real clean week from 'not scanned yet'
 
         if count_changes(analyses) == 0:
             # Quiet code week, but the security roll-up still ships the reassurance. No LLM needed.
@@ -230,7 +244,7 @@ if groups:
                               brain_block(profiles))
         try:
             result = waveassist.call_llm(model=model_name, prompt=prompt, response_model=TechnicalReport,
-                                         max_tokens=MAX_TOKENS, temperature=TEMPERATURE)
+                                         max_tokens=MAX_TOKENS)
         except Exception as e:
             print(f"⚠️ technical LLM failed for {slug}: {e}")
             result = None

--- a/send_digest.py
+++ b/send_digest.py
@@ -92,9 +92,17 @@ def render_group_preview(group_name, recipients, sent, body_html):
 
 
 def render_security_rollup_html(rollup) -> str:
-    """The 'we watched, here is the state' section. Always rendered, even at zero (that IS the value)."""
+    """The 'we watched, here is the state' section. When Security Watch HAS scanned this group's repos,
+    it always renders even at zero — the clean-week all-clear is the value. But before any scan has
+    happened (first digest firing before Security Watch has run, or a digest group whose repos no
+    security group covers), an empty roll-up is NOT an all-clear — claiming 'nothing found' then would
+    contradict the very first security alert email. In that case the section is hidden entirely until a
+    scan genuinely happens (`scanned` set by generate_technical_report)."""
     rollup = rollup or {}
     counts = rollup.get("counts", {"new": 0, "still_open": 0, "resolved": 0})
+    all_zero = not (counts.get("new") or counts.get("still_open") or counts.get("resolved"))
+    if all_zero and not rollup.get("scanned"):
+        return ""
 
     def row(item):
         kev = " <span class='kev'>&middot; actively exploited</span>" if item.get("actively_exploited") else ""
@@ -108,7 +116,7 @@ def render_security_rollup_html(rollup) -> str:
     def group(label, items):
         return (f"<div class='sec-group-label'>{label}</div>" + "".join(row(i) for i in items)) if items else ""
 
-    if not (counts.get("new") or counts.get("still_open") or counts.get("resolved")):
+    if all_zero:                       # scanned this week (guaranteed by the guard above) and clean
         body = ("<p class='success'>No security issues found this week. GitZoid watched your dependencies "
                 "and code and found nothing exploitable.</p>")
     else:
@@ -219,8 +227,10 @@ def build_email_html(group_name, business_report, technical_report, stats, date_
         poem_html = ("<div class='poem'><h3>A small poem for this week:</h3><em>"
                      + "".join(f"<p class='poem-line'>{_esc(l)}</p>" for l in poem) + "</em></div>")
         # Separate the poem from the security section above it (on a clean week the short "nothing
-        # found" line otherwise runs straight into the poem).
-        poem_divider = "<hr style='border:0;border-top:1px solid #e5e7eb;margin:22px 0' />"
+        # found" line otherwise runs straight into the poem). Only when that section is actually
+        # present — if the roll-up is hidden (not scanned yet) the divider would dangle.
+        if rollup_html:
+            poem_divider = "<hr style='border:0;border-top:1px solid #e5e7eb;margin:22px 0' />"
 
     period = ""
     if date_range and date_range.get("start_date_formatted"):

--- a/tests/unit/test_generate_technical_report.py
+++ b/tests/unit/test_generate_technical_report.py
@@ -138,6 +138,25 @@ class TestDriver:
         assert "security_rollup" in reports["idle"]            # reassurance present even when quiet
         assert reports["idle"]["security_rollup"]["counts"]["new"] == 1
 
+    def test_rollup_scanned_flag_tracks_dependency_snapshot(self, monkeypatch):
+        """The roll-up carries scanned=True iff Security Watch has scanned a group repo (a
+        dependency_snapshot exists), so send_digest can tell a real clean week from 'not scanned yet'."""
+        groups = [{"name": "Idle", "repos": ["o/a"], "recipients": [], "slug": "idle"}]
+        base = {
+            "digest_skip_run": "0",
+            "digest_resolved_groups": groups,
+            "repository_analyses": [{"repository": "o/a", "changes": []}],
+            "digest_business_reports": {},
+            "security_findings": {},
+        }
+        no_llm = lambda *a, **k: (_ for _ in ()).throw(AssertionError("no LLM for a quiet group"))
+
+        not_scanned = self._run(monkeypatch, dict(base), llm=no_llm)
+        assert not_scanned["digest_technical_reports"]["idle"]["security_rollup"]["scanned"] is False
+
+        scanned = self._run(monkeypatch, {**base, "dependency_snapshot:o/a": {"hash": "abc"}}, llm=no_llm)
+        assert scanned["digest_technical_reports"]["idle"]["security_rollup"]["scanned"] is True
+
     def test_quiet_group_not_flagged_failed(self, monkeypatch):
         """A quiet week keeps the QUIET poem and is NOT flagged as a generation failure."""
         groups = [{"name": "Idle", "repos": ["o/a"], "recipients": [], "slug": "idle"}]

--- a/tests/unit/test_send_digest.py
+++ b/tests/unit/test_send_digest.py
@@ -56,10 +56,23 @@ class TestRenderSecurityRollup:
         assert "SQLi" in h
         assert "patched dep" in h
 
-    def test_clean_week_message(self):
+    def test_clean_week_message_when_scanned(self):
+        # scanned + zero findings = a genuine all-clear -> the reassurance line ships.
+        h = render_security_rollup_html({"new": [], "still_open": [], "resolved": [], "scanned": True,
+                                         "counts": {"new": 0, "still_open": 0, "resolved": 0}})
+        assert "no security issues found" in h.lower()   # reassurance, not blank
+        assert "<h2>Security</h2>" in h
+
+    def test_hidden_when_not_scanned_yet(self):
+        # zero findings but NOT yet scanned (e.g. first run before Security Watch has run) = 'not
+        # scanned', not an all-clear -> hide the section rather than post a false 'nothing found'.
         h = render_security_rollup_html({"new": [], "still_open": [], "resolved": [],
                                          "counts": {"new": 0, "still_open": 0, "resolved": 0}})
-        assert "no" in h.lower()               # reassurance, not blank
+        assert h == ""
+
+    def test_findings_always_render_regardless_of_scanned_flag(self):
+        # A non-empty roll-up was obviously scanned; render it even if the flag is missing.
+        assert "SQLi" in render_security_rollup_html(ROLLUP)
 
 
 class TestGroupGenerationFailed:
@@ -343,10 +356,11 @@ class TestSecurityPoemDivider:
     def test_divider_sits_between_security_and_poem(self):
         business = {"executive_summary": "a quiet week", "shipped_features": []}
         technical = {"repository_deep_dive": [], "poem": ["line one", "line two"],
-                     "security_rollup": {"counts": {"new": 0, "still_open": 0, "resolved": 0}}}
+                     "security_rollup": {"scanned": True,
+                                         "counts": {"new": 0, "still_open": 0, "resolved": 0}}}
         html = build_email_html("All repositories", business, technical, {"commits": 0}, {})
         assert "<hr" in html
-        sec = html.index("SECURITY")
+        sec = html.index("<h2>Security</h2>")
         poem = html.index("A small poem")
         hr = html.index("<hr", sec)
         assert sec < hr < poem            # divider between the security section and the poem
@@ -354,10 +368,21 @@ class TestSecurityPoemDivider:
     def test_no_dangling_divider_without_poem(self):
         business = {"executive_summary": "s", "shipped_features": []}
         technical = {"repository_deep_dive": [], "poem": [],
-                     "security_rollup": {"counts": {"new": 0, "still_open": 0, "resolved": 0}}}
+                     "security_rollup": {"scanned": True,
+                                         "counts": {"new": 0, "still_open": 0, "resolved": 0}}}
         html = build_email_html("All repositories", business, technical, {"commits": 0}, {})
         assert "A small poem" not in html
         assert "<hr" not in html           # no poem -> no divider
+
+    def test_no_divider_when_security_section_hidden(self):
+        # Not scanned yet -> security section hidden -> the poem divider must not dangle above the poem.
+        business = {"executive_summary": "s", "shipped_features": []}
+        technical = {"repository_deep_dive": [], "poem": ["line one", "line two"],
+                     "security_rollup": {"counts": {"new": 0, "still_open": 0, "resolved": 0}}}
+        html = build_email_html("All repositories", business, technical, {"commits": 0}, {})
+        assert "<h2>Security</h2>" not in html   # section hidden
+        assert "A small poem" in html            # poem still present
+        assert "<hr" not in html                 # no security section -> no divider
 
 
 class TestDigestStatus:

--- a/tests/unit/test_triage_and_alert.py
+++ b/tests/unit/test_triage_and_alert.py
@@ -495,24 +495,29 @@ class TestIssueCountGrouped:
 
 
 class TestSubjectMultiRepo:
-    """Fix D: when findings span multiple repos the subject must not name just one repo."""
+    """The subject is generic and count-only: it never names a repo (names are long/random and ugly
+    in a subject) and never states a repo/group count (each group emails only its own slice, so a
+    count reads as misleading), regardless of how many repos the findings span."""
 
     def _f(self, repo, sev="high", **kw):
         return {"category": "authz", "repo": repo, "title": f"bug in {repo}",
                 "severity": sev, "impact": "x", **kw}
 
-    def test_single_repo_names_the_repo(self):
+    def test_single_repo_is_not_named(self):
         s = build_subject([self._f("o/r")])
-        assert "in o/r" in s
+        assert s == "GitZoid Security: 1 issue found"
+        assert "o/r" not in s
 
-    def test_multi_repo_says_count_of_repos(self):
+    def test_multi_repo_does_not_count_repos(self):
         s = build_subject([self._f("o/a"), self._f("o/b")])
-        assert "2 repositories" in s
-        assert "GitZoid Security" in s
+        assert s == "GitZoid Security: 2 issues found"
+        assert "repositories" not in s
+        assert "o/a" not in s and "o/b" not in s
 
-    def test_kev_multi_repo_mentions_more(self):
+    def test_kev_does_not_change_the_subject(self):
         s = build_subject([self._f("o/a", actively_exploited=True), self._f("o/b")])
-        assert "actively exploited" in s and "more" in s
+        assert s == "GitZoid Security: 2 issues found"
+        assert "actively exploited" not in s
 
 
 # ---------------------------------------------------------------- group routing (per-group delivery)

--- a/triage_and_alert.py
+++ b/triage_and_alert.py
@@ -379,16 +379,12 @@ def build_alert_email(code_findings, dep_findings, scanned_repos):
 
 
 def build_subject(findings):
-    top = findings[0]
-    repos = {f.get("repo") for f in findings if f.get("repo")}
-    multi = len(repos) > 1
+    # One generic, count-only subject every time — no repo names (long/random, ugly in a subject),
+    # no repo/group count (each group emails its own slice, so a count reads as misleading), and no
+    # KEV special-case (urgency is flagged inside the email). Matches the body header's "issues found"
+    # wording so subject and body speak the same language.
     n = _issue_count(findings)              # count grouped issues (a package = 1), not raw CVEs
-    count = f"{n} issues" if n != 1 else "1 issue"
-    if top.get("actively_exploited"):
-        where = (top.get("repo") or "your repos") + (f" and {len(repos) - 1} more" if multi else "")
-        return f"GitZoid Security: actively exploited issue in {where}"
-    where = f"{len(repos)} repositories" if multi else (top.get("repo") or "your repos")
-    return f"GitZoid Security: {count} in {where}"
+    return f"GitZoid Security: {n} issue{'s' if n != 1 else ''} found"
 
 
 # ---------------------------------------------------------------- group routing (per-group delivery)


### PR DESCRIPTION
- Remove explicit temperature from report/analysis LLM calls
- Gate the security roll-up until a scan has actually run
- Simplify the security alert email subject